### PR TITLE
Add cron with XML change detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+  schedule:
+    - cron: '0 0 * * *'
 
 permissions:
   contents: read
@@ -18,23 +20,59 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      xml_changed: ${{ steps.diff.outputs.changed }}
 
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
+      - name: Cache XML feed
+        id: xml_cache
+        uses: actions/cache@v3
+        with:
+          path: .cache/xml-feed.xml
+          key: xml-feed-${{ github.run_id }}
+          restore-keys: xml-feed-
+
+      - name: Fetch latest XML
+        run: |
+          mkdir -p .cache
+          curl -sL 'https://www.youtube.com/feeds/videos.xml?channel_id=UCS4KTDaZTiyiMj2yZztwmlg' -o .cache/current.xml
+
+      - name: Check XML changes
+        id: diff
+        shell: bash
+        run: |
+          if [ -f .cache/xml-feed.xml ]; then
+            if diff -q .cache/xml-feed.xml .cache/current.xml > /dev/null; then
+              echo "changed=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "changed=true" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Update cached XML
+        run: mv .cache/current.xml .cache/xml-feed.xml
+
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
+        if: steps.diff.outputs.changed == 'true'
         uses: ./.github/workflows/setup-node
 
       - name: Setup Pages ⚙️
+        if: steps.diff.outputs.changed == 'true'
         uses: actions/configure-pages@v4
         with:
           static_site_generator: next
 
       - name: Build with Next.js 🏗️
+        if: steps.diff.outputs.changed == 'true'
         run: npx next build
 
       - name: Upload artifact 📡
+        if: steps.diff.outputs.changed == 'true'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
@@ -46,6 +84,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: build
+    if: needs.build.outputs.xml_changed == 'true'
 
     steps:
       - name: Publish to GitHub Pages 🚀

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![NextJS](https://img.shields.io/badge/--3178C6?logo=next.js&logoColor=ffffff)](https://nextjs.org/)
 [![publish-to-github-pages](https://github.com/SecuringTheRealm/securingtherealm.github.io/actions/workflows/publish.yml/badge.svg)](https://github.com/SecuringTheRealm/securingtherealm.github.io/actions/workflows/publish.yml)
 
+This workflow runs daily and deploys only when the fetched XML feed has changed.
 
 ### Installation
 


### PR DESCRIPTION
## Summary
- run the publish workflow on a daily schedule
- cache the previous XML feed and compare it before deploying
- only deploy if the XML feed changed
- update README to describe daily workflow behavior

## Testing
- `npx biome format .` *(fails: EHOSTUNREACH)*
- `npx biome check .` *(fails: EHOSTUNREACH)*
- `npm run lint`