### PR TITLE
Fix manual deploy workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,21 +58,21 @@ jobs:
         run: mv .cache/current.xml .cache/xml-feed.xml
 
       - name: Setup Node.js ⚙️ - Cache dependencies ⚡ - Install dependencies 🔧
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: ./.github/workflows/setup-node
 
       - name: Setup Pages ⚙️
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/configure-pages@v4
         with:
           static_site_generator: next
 
       - name: Build with Next.js 🏗️
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         run: npx next build
 
       - name: Upload artifact 📡
-        if: steps.diff.outputs.changed == 'true'
+        if: steps.diff.outputs.changed == 'true' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./out
@@ -84,7 +84,7 @@ jobs:
 
     runs-on: ubuntu-latest
     needs: build
-    if: needs.build.outputs.xml_changed == 'true'
+    if: needs.build.outputs.xml_changed == 'true' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Publish to GitHub Pages 🚀


### PR DESCRIPTION
## Summary
- update workflow to redeploy on manual run even when xml file doesn't change

## Testing
- `npx biome format . --write` *(fails: No files were processed)*
- `npx biome check .` *(fails: many formatting issues)*
- `npm run lint` *(fails: many formatting issues)*