### PR TITLE
feat: collapse chapters in video descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2025-08-08
+
+- Render video chapters as collapsible section
+
 ## 2025-03-22
 
 - Update template to Tailwind CSS v4.0.15

--- a/src/__tests__/MarkdownDescription.test.tsx
+++ b/src/__tests__/MarkdownDescription.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import { MarkdownDescription } from '../components/MarkdownDescription'
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}))
+jest.mock('remark-breaks', () => () => null)
+
+describe('MarkdownDescription', () => {
+  it('renders basic text', () => {
+    render(<MarkdownDescription description="Just text" />)
+    expect(screen.getByText('Just text')).toBeInTheDocument()
+  })
+
+  it('renders chapters as collapsible list', () => {
+    const desc = `Intro\n\nChapters\n00:00 Start\n01:00 Middle\n`
+    render(<MarkdownDescription description={desc} />)
+
+    const summary = screen.getByText('Chapters')
+    expect(summary.tagName).toBe('SUMMARY')
+
+    const details = summary.closest('details')
+    expect(details).toBeInTheDocument()
+    expect(details).not.toHaveAttribute('open')
+
+    expect(screen.getByText('00:00 Start')).toBeInTheDocument()
+    expect(screen.getByText('01:00 Middle')).toBeInTheDocument()
+  })
+})

--- a/src/components/MarkdownDescription.tsx
+++ b/src/components/MarkdownDescription.tsx
@@ -12,60 +12,103 @@ export function MarkdownDescription({ description, className = '' }: MarkdownDes
     return null
   }
 
+  const markdownComponents = {
+    // Style links to match the design
+    a: ({ children, href, ...props }) => (
+      <a
+        href={href}
+        className="text-pink-500 hover:text-pink-700 underline"
+        target="_blank"
+        rel="noopener noreferrer"
+        {...props}
+      >
+        {children}
+      </a>
+    ),
+    // Style lists with proper spacing and inherit text styles
+    ul: ({ children, ...props }) => (
+      <ul className="list-disc list-inside space-y-1 mt-2" {...props}>
+        {children}
+      </ul>
+    ),
+    ol: ({ children, ...props }) => (
+      <ol className="list-decimal list-inside space-y-1 mt-2" {...props}>
+        {children}
+      </ol>
+    ),
+    li: ({ children, ...props }) => (
+      <li className="text-inherit" {...props}>
+        {children}
+      </li>
+    ),
+    // Handle paragraphs inline for description context
+    p: ({ children, ...props }) => (
+      <span {...props}>
+        {children}
+      </span>
+    ),
+    // Style emphasis and strong text
+    em: ({ children, ...props }) => (
+      <em className="italic" {...props}>
+        {children}
+      </em>
+    ),
+    strong: ({ children, ...props }) => (
+      <strong className="font-semibold" {...props}>
+        {children}
+      </strong>
+    ),
+  } as const
+
+  const chaptersMatch = description.match(/(^|\n)Chapters\n((?:\d{1,2}:\d{2}(?::\d{2})? .*\n?)+)/i)
+
+  const preText = chaptersMatch
+    ? description.slice(0, chaptersMatch.index ?? 0).trim()
+    : description
+
+  const postText = chaptersMatch
+    ? description
+        .slice((chaptersMatch.index ?? 0) + chaptersMatch[0].length)
+        .trim()
+    : ''
+
+  const chapterLines = chaptersMatch
+    ? chaptersMatch[2]
+        .trim()
+        .split('\n')
+        .map((line) => line.trim())
+    : []
+
   return (
     <div className={className}>
-      <ReactMarkdown
-        remarkPlugins={[remarkBreaks]}
-        components={{
-          // Style links to match the design
-          a: ({ children, href, ...props }) => (
-            <a
-              href={href}
-              className="text-pink-500 hover:text-pink-700 underline"
-              target="_blank"
-              rel="noopener noreferrer"
-              {...props}
-            >
-              {children}
-            </a>
-          ),
-          // Style lists with proper spacing and inherit text styles
-          ul: ({ children, ...props }) => (
-            <ul className="list-disc list-inside space-y-1 mt-2" {...props}>
-              {children}
-            </ul>
-          ),
-          ol: ({ children, ...props }) => (
-            <ol className="list-decimal list-inside space-y-1 mt-2" {...props}>
-              {children}
-            </ol>
-          ),
-          li: ({ children, ...props }) => (
-            <li className="text-inherit" {...props}>
-              {children}
-            </li>
-          ),
-          // Handle paragraphs inline for description context
-          p: ({ children, ...props }) => (
-            <span {...props}>
-              {children}
-            </span>
-          ),
-          // Style emphasis and strong text
-          em: ({ children, ...props }) => (
-            <em className="italic" {...props}>
-              {children}
-            </em>
-          ),
-          strong: ({ children, ...props }) => (
-            <strong className="font-semibold" {...props}>
-              {children}
-            </strong>
-          ),
-        }}
-      >
-        {description}
-      </ReactMarkdown>
+      {preText && (
+        <ReactMarkdown
+          remarkPlugins={[remarkBreaks]}
+          components={markdownComponents}
+        >
+          {preText}
+        </ReactMarkdown>
+      )}
+      {chapterLines.length > 0 && (
+        <details className="mt-2">
+          <summary className="cursor-pointer text-pink-500 hover:text-pink-700">
+            Chapters
+          </summary>
+          <ul className="list-disc list-inside space-y-1 mt-2">
+            {chapterLines.map((line, index) => (
+              <li key={index}>{line}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+      {postText && (
+        <ReactMarkdown
+          remarkPlugins={[remarkBreaks]}
+          components={markdownComponents}
+        >
+          {postText}
+        </ReactMarkdown>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- collapse chapter lists in descriptions behind a default-closed details block
- cover collapsible chapter rendering with tests

## Testing
- `npx biome format src/components/MarkdownDescription.tsx src/__tests__/MarkdownDescription.test.tsx CHANGELOG.md`
- `npx biome check .`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689645d57ed0833288185ccb08ace861