### PR TITLE
chore: dependency bumps, homepage rebuild, spacing token system

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,76 @@ jobs:
 
       - name: Run tests (lint + type check) 🔍
         run: bun run test
+
+      # Build here so the content lint below sees the real rendered output,
+      # including YouTube descriptions fetched at build time that never
+      # appear in src/. Deliberately after the offline checks above, so an
+      # unreachable feed cannot mask the lint and type-check verdict.
+      - name: Build site 🏗️
+        run: bun run build
+
+      - name: Content lint (prose) 📝
+        run: |
+          cat > "$RUNNER_TEMP/lint-content.mjs" <<'LINT'
+          import { readFileSync, readdirSync } from "node:fs";
+          import { join } from "node:path";
+
+          const RULES = [
+            [/—|&mdash;|&#8212;|&#x2014;/gi, "em dash"],
+            [/\bdelv(e|es|ed|ing)\b/gi, "delve"],
+          ];
+
+          // Non-prose regions, blanked before matching. Order matters: the
+          // escape hatch and code samples must go before the catch-all tag strip.
+          const STRIP = [
+            /<script\b[\s\S]*?<\/script>/gi,
+            /<style\b[\s\S]*?<\/style>/gi,
+            /<pre\b[\s\S]*?<\/pre>/gi,
+            /<code\b[\s\S]*?<\/code>/gi,
+            /<(\w+)\b[^>]*\sdata-lint-ignore\b[\s\S]*?<\/\1>/gi,
+            /<!--[\s\S]*?-->/g,
+            /<[^>]+>/g, // tags: attributes, URLs, embed params
+          ];
+
+          const root = process.argv[2] ?? "dist";
+          const blank = (m) => m.replace(/[^\n]/g, " "); // keep byte offsets stable
+
+          let failures = 0;
+          const files = readdirSync(root, { recursive: true }).filter((f) =>
+            f.endsWith(".html"),
+          );
+
+          // A missing or empty dist must fail loudly: a lint that passes
+          // because it found nothing to check is worse than no lint at all.
+          if (files.length === 0) {
+            console.error(`content lint: no HTML found under ${root} — did the build run?`);
+            process.exit(1);
+          }
+
+          for (const file of files.sort()) {
+            const path = join(root, file);
+            const html = readFileSync(path, "utf8");
+            const prose = STRIP.reduce((s, re) => s.replace(re, blank), html);
+
+            for (const [rule, name] of RULES) {
+              for (const m of prose.matchAll(rule)) {
+                const line = html.slice(0, m.index).split("\n").length;
+                const col = m.index - (html.lastIndexOf("\n", m.index - 1) + 1) + 1;
+                const context = html
+                  .slice(Math.max(0, m.index - 70), m.index + 70)
+                  .replace(/\s+/g, " ");
+                console.error(`${path}:${line}:${col}  ${name}: …${context}…`);
+                failures++;
+              }
+            }
+          }
+
+          if (failures > 0) {
+            console.error(
+              `\n${failures} content lint failure(s) in ${root}. Fix the source, or wrap a deliberate use in an element carrying data-lint-ignore.`,
+            );
+            process.exit(1);
+          }
+          console.log(`content lint: ${files.length} pages clean`);
+          LINT
+          bun "$RUNNER_TEMP/lint-content.mjs" dist

--- a/.gitignore
+++ b/.gitignore
@@ -1169,3 +1169,4 @@ web-bundles/
 docs/architecture/
 docs/prd/
 .claude/settings.local.json
+qa/screenshots/

--- a/bun.lock
+++ b/bun.lock
@@ -5,10 +5,10 @@
     "": {
       "name": "securing-the-realm",
       "dependencies": {
-        "@astrojs/check": "^0.9.5",
-        "@astrojs/mdx": "^5.0.3",
-        "@astrojs/sitemap": "^3.6.0",
-        "astro": "^6.1.8",
+        "@astrojs/check": "^0.9.9",
+        "@astrojs/mdx": "^7.0.3",
+        "@astrojs/sitemap": "^3.7.3",
+        "astro": "^7.1.3",
         "fast-xml-parser": "^5.3.6",
         "typescript": "^5.9.3",
         "unist-util-visit": "^5.1.0",
@@ -17,7 +17,7 @@
         "@biomejs/biome": "2.4.4",
         "@types/hast": "^3.0.4",
         "@types/node": "^25.5.0",
-        "sharp": "^0.34.5",
+        "sharp": "^0.35.3",
       },
     },
   },
@@ -25,25 +25,49 @@
     "@biomejs/biome",
   ],
   "packages": {
-    "@astrojs/check": ["@astrojs/check@0.9.6", "", { "dependencies": { "@astrojs/language-server": "^2.16.1", "chokidar": "^4.0.1", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-jlaEu5SxvSgmfGIFfNgcn5/f+29H61NJzEMfAZ82Xopr4XBchXB1GVlcJsE+elUlsYSbXlptZLX+JMG3b/wZEA=="],
+    "@astrojs/check": ["@astrojs/check@0.9.9", "", { "dependencies": { "@astrojs/language-server": "^2.16.7", "chokidar": "^4.0.3", "kleur": "^4.1.5", "yargs": "^17.7.2" }, "peerDependencies": { "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "astro-check": "bin/astro-check.js" } }, "sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg=="],
 
-    "@astrojs/compiler": ["@astrojs/compiler@3.0.1", "", {}, "sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA=="],
+    "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
-    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.9.0", "", { "dependencies": { "picomatch": "^4.0.4" } }, "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg=="],
+    "@astrojs/compiler-binding": ["@astrojs/compiler-binding@0.3.1", "", { "optionalDependencies": { "@astrojs/compiler-binding-darwin-arm64": "0.3.1", "@astrojs/compiler-binding-darwin-x64": "0.3.1", "@astrojs/compiler-binding-linux-arm64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-arm64-musl": "0.3.1", "@astrojs/compiler-binding-linux-x64-gnu": "0.3.1", "@astrojs/compiler-binding-linux-x64-musl": "0.3.1", "@astrojs/compiler-binding-wasm32-wasi": "0.3.1", "@astrojs/compiler-binding-win32-arm64-msvc": "0.3.1", "@astrojs/compiler-binding-win32-x64-msvc": "0.3.1" } }, "sha512-DaAUj29AIBU2XdJ8uwcab8lW5O2pk9pY8AXkcMw0sw77nVa3oeTYRcO+Dvbbpoexf6ThMc0FMWYCQ/wN1/T7oQ=="],
 
-    "@astrojs/language-server": ["@astrojs/language-server@2.16.3", "", { "dependencies": { "@astrojs/compiler": "^2.13.0", "@astrojs/yaml2ts": "^0.2.2", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.27", "@volar/language-core": "~2.4.27", "@volar/language-server": "~2.4.27", "@volar/language-service": "~2.4.27", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.15", "volar-service-css": "0.0.68", "volar-service-emmet": "0.0.68", "volar-service-html": "0.0.68", "volar-service-prettier": "0.0.68", "volar-service-typescript": "0.0.68", "volar-service-typescript-twoslash-queries": "0.0.68", "volar-service-yaml": "0.0.68", "vscode-html-languageservice": "^5.6.1", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "bin/nodeServer.js" } }, "sha512-yO5K7RYCMXUfeDlnU6UnmtnoXzpuQc0yhlaCNZ67k1C/MiwwwvMZz+LGa+H35c49w5QBfvtr4w4Zcf5PcH8uYA=="],
+    "@astrojs/compiler-binding-darwin-arm64": ["@astrojs/compiler-binding-darwin-arm64@0.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-IEmEF2fUIlTHtpeE/isyEGVOB14cEyh/LZOFYt6wn3jNyVpdC8aR5OZ+RzFUR/f+8ZDM1LaMwZKvoA7eMyJeFw=="],
 
-    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.1.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.9.0", "@astrojs/prism": "4.0.1", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "js-yaml": "^4.1.1", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "retext-smartypants": "^6.2.0", "shiki": "^4.0.0", "smol-toml": "^1.6.0", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA=="],
+    "@astrojs/compiler-binding-darwin-x64": ["@astrojs/compiler-binding-darwin-x64@0.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-GF2kIxjpPDLsn94zbZNMsxEmkU828QqnmM7kiQJnaooS3jmI+I7kk6+oI6EpwOsK3femCMdcm+wmOsEqtGrmjQ=="],
 
-    "@astrojs/mdx": ["@astrojs/mdx@5.0.4", "", { "dependencies": { "@astrojs/markdown-remark": "7.1.1", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "astro": "^6.0.0" } }, "sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA=="],
+    "@astrojs/compiler-binding-linux-arm64-gnu": ["@astrojs/compiler-binding-linux-arm64-gnu@0.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XJL3SDmOtVrqFhCirNcHwE91+IesJqlgNo23I4qW9QUYfwzm/TBZuH61fgqsb1ttgR1mMYz6ooPWs0JDhwMqpQ=="],
 
-    "@astrojs/prism": ["@astrojs/prism@4.0.1", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ=="],
+    "@astrojs/compiler-binding-linux-arm64-musl": ["@astrojs/compiler-binding-linux-arm64-musl@0.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-xqE8BVbDoBueK/B47w30PtkVofUWJKGkwoMVE+EOMLf11rnoANxIAdA9FPqY+rng4oNI5ndHGsri1yPj2k8vZQ=="],
 
-    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.0", "", { "dependencies": { "sitemap": "^8.0.2", "stream-replace-string": "^2.0.0", "zod": "^3.25.76" } }, "sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA=="],
+    "@astrojs/compiler-binding-linux-x64-gnu": ["@astrojs/compiler-binding-linux-x64-gnu@0.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-1y0StU1qiCuDFH3rmbRJXcxdfHxFPrES1Rd+RLffosvUR7I2cH5SF5SFnBN9vXpzpkmyElZm3Yr47iJBPN7vVA=="],
 
-    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.1", "", { "dependencies": { "ci-info": "^4.4.0", "dlv": "^1.1.3", "dset": "^3.1.4", "is-docker": "^4.0.0", "is-wsl": "^3.1.1", "which-pm-runs": "^1.1.0" } }, "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw=="],
+    "@astrojs/compiler-binding-linux-x64-musl": ["@astrojs/compiler-binding-linux-x64-musl@0.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-16q0fYf7kpbmdObZEeZJEup8hQv/whgNwVjrSvT8umrKwLDSnNIWiQpm09lQQu6bweZB0XyIvHwlPitvJhC+hg=="],
 
-    "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.2", "", { "dependencies": { "yaml": "^2.5.0" } }, "sha512-GOfvSr5Nqy2z5XiwqTouBBpy5FyI6DEe+/g/Mk5am9SjILN1S5fOEvYK0GuWHg98yS/dobP4m8qyqw/URW35fQ=="],
+    "@astrojs/compiler-binding-wasm32-wasi": ["@astrojs/compiler-binding-wasm32-wasi@0.3.1", "", { "dependencies": { "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-cB456shIwDv/PrVT+2QG7LFndpHkVge5HjqADKZgGaAc9JHVktCtjSrcdkRQ+3tbkPazNKaTLRjXLIiz2NIx9g=="],
+
+    "@astrojs/compiler-binding-win32-arm64-msvc": ["@astrojs/compiler-binding-win32-arm64-msvc@0.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-ur/9+If/yTE69mmeX5MqSZndL0HOyx67GeNZUy3N7wVdWpLz9UTJXwyWS4UR2PUQHitghjsM5xoX0Ge56WRVQQ=="],
+
+    "@astrojs/compiler-binding-win32-x64-msvc": ["@astrojs/compiler-binding-win32-x64-msvc@0.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-k0W+kDBzDkNZOqu4kElDvCOIbKw5Ut9S1WZ1Krj3KTgNuBERNKXsMMsRLLcbgfdMdbe7bTekQLshZrrvmYpmwA=="],
+
+    "@astrojs/compiler-rs": ["@astrojs/compiler-rs@0.3.1", "", { "dependencies": { "@astrojs/compiler-binding": "0.3.1" } }, "sha512-aT7xkgsbNoS6nriY5qKpbihK43slFHO41iqgHCTdOvn1ifaQxLCc5yXy+6GzAtiafoaC1zA7OwVXCXMsvUZOkg=="],
+
+    "@astrojs/internal-helpers": ["@astrojs/internal-helpers@0.10.1", "", { "dependencies": { "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "js-yaml": "^4.1.1", "picomatch": "^4.0.4", "retext-smartypants": "^6.2.0", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "unified": "^11.0.5" } }, "sha512-5phcroT/vmOOrYuuAxtkbPixy5hePtlz9i8K4OeDv3dNK6/UQRuXPOSRTxIOBbUY5Sonw2UaxjbuVc43Mcir6Q=="],
+
+    "@astrojs/language-server": ["@astrojs/language-server@2.16.13", "", { "dependencies": { "@astrojs/compiler": "^2.13.1", "@astrojs/yaml2ts": "^0.2.4", "@jridgewell/sourcemap-codec": "^1.5.5", "@volar/kit": "~2.4.28", "@volar/language-core": "~2.4.28", "@volar/language-server": "~2.4.28", "@volar/language-service": "~2.4.28", "muggle-string": "^0.4.1", "tinyglobby": "^0.2.16", "volar-service-css": "0.0.71", "volar-service-emmet": "0.0.71", "volar-service-html": "0.0.71", "volar-service-prettier": "0.0.71", "volar-service-typescript": "0.0.71", "volar-service-typescript-twoslash-queries": "0.0.71", "volar-service-yaml": "0.0.71", "vscode-html-languageservice": "^5.6.2", "vscode-uri": "^3.1.0" }, "peerDependencies": { "prettier": "^3.0.0", "prettier-plugin-astro": ">=0.11.0" }, "optionalPeers": ["prettier", "prettier-plugin-astro"], "bin": { "astro-ls": "./bin/nodeServer.js" } }, "sha512-ekOa+CYprEq5n4EJC1qTIAhLk49HZIUQuFwrEuF+3JK/pdMaYnWoREFUI2A0KEPOJiFA2kamBzKzbYljDvUxLg=="],
+
+    "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.1", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-jPVNIqTvk+yKviikszv/Y1U4jGUSKpp/Nw48QZV4qjWgp70j4Lkq3lhSDRbWwCfgKvEyO9GHuVbV1dM2WYXy1w=="],
+
+    "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.4", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-6Lvt/bQZEBW+zzdhPblvfZEy5PGEYJaUsUqaCgwHeRPxZJL1gc9I+DRLKWJjjYTWDzVUTzXlMq4WwSK+X34CVw=="],
+
+    "@astrojs/mdx": ["@astrojs/mdx@7.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-remark": "7.2.1", "@mdx-js/mdx": "^3.1.1", "acorn": "^8.16.0", "es-module-lexer": "^2.0.0", "estree-util-visit": "^2.0.0", "hast-util-to-html": "^9.0.5", "piccolore": "^0.1.3", "rehype-raw": "^7.0.0", "remark-gfm": "^4.0.1", "remark-smartypants": "^3.0.2", "source-map": "^0.7.6", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@astrojs/markdown-satteri": "^0.3.1", "astro": "^7.0.0" }, "optionalPeers": ["@astrojs/markdown-satteri"] }, "sha512-RxyIwU0uFam5ftwqKOjpIdhnFxZ/kEikeimLyQy3eGXbHT8WgRGzzesOIHVU8+m9TY8ag5WVOyvV24/GyqPdPQ=="],
+
+    "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.3", "", { "dependencies": { "sitemap": "^9.0.0", "stream-replace-string": "^2.0.0", "zod": "^4.3.6" } }, "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA=="],
+
+    "@astrojs/telemetry": ["@astrojs/telemetry@3.3.3", "", { "dependencies": { "ci-info": "^4.4.0", "dset": "^3.1.4", "is-docker": "^4.0.0", "package-manager-detector": "^1.6.0" } }, "sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ=="],
+
+    "@astrojs/yaml2ts": ["@astrojs/yaml2ts@0.2.4", "", { "dependencies": { "yaml": "^2.8.3" } }, "sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A=="],
 
     "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
 
@@ -71,6 +95,24 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.4", "", { "os": "win32", "cpu": "x64" }, "sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A=="],
 
+    "@bruits/satteri-darwin-arm64": ["@bruits/satteri-darwin-arm64@0.9.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-iw4nZgx9v30lWo/MTngQqi1pI78KI0DnkSm+lVJGYdmPLgAyDNJigVhpG42/Iq55A6c1Ll8q66ljyyRiQUxwow=="],
+
+    "@bruits/satteri-darwin-x64": ["@bruits/satteri-darwin-x64@0.9.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-6T26Z5Kf3cFW2PSlk9p7zT7yVxvuBSiJvYyz9u8KjYwMTqZyIDOj2wDyNpxKV4+6yUVG7rddq2QwvG/8LJA2+Q=="],
+
+    "@bruits/satteri-linux-arm64-gnu": ["@bruits/satteri-linux-arm64-gnu@0.9.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-u51id17uJwNEMK9nBlICsq6U31c+XVqQueVBkwRIzZG+gMpS8TOJctt5h5Wz33Z8xnMdTd+adtACVz0yHgGuOA=="],
+
+    "@bruits/satteri-linux-arm64-musl": ["@bruits/satteri-linux-arm64-musl@0.9.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ=="],
+
+    "@bruits/satteri-linux-x64-gnu": ["@bruits/satteri-linux-x64-gnu@0.9.5", "", { "os": "linux", "cpu": "x64" }, "sha512-F3uO8uFp3pAP5ZGXttwvh57GS7s0lL953tnNdyI2gRyP4kOOkp6pyGojNJzCjkDvWI2Cvb9iNrKok3aqQPauAw=="],
+
+    "@bruits/satteri-linux-x64-musl": ["@bruits/satteri-linux-x64-musl@0.9.5", "", { "os": "linux", "cpu": "x64" }, "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q=="],
+
+    "@bruits/satteri-wasm32-wasi": ["@bruits/satteri-wasm32-wasi@0.9.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-zauAuMwfPnKPUkd4AFixRFpXdgKwP2mKgxrIIo2gJzW0/ZneF9dbHnLkojSpaBnCCp7VUL1hIi5WWZvB1CqmAQ=="],
+
+    "@bruits/satteri-win32-arm64-msvc": ["@bruits/satteri-win32-arm64-msvc@0.9.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-SrfE7NEsgZjBvU3c+RR6oQRu0ToXY5uVJEbieXEF0YTctIV2zAVlbaMjWLts074QCgh3a+XHWkR/lWh2VH2LUg=="],
+
+    "@bruits/satteri-win32-x64-msvc": ["@bruits/satteri-win32-x64-msvc@0.9.5", "", { "os": "win32", "cpu": "x64" }, "sha512-5Kw9ZAtTGS8WHizyn+CJhjjfIQrw+7jcZodpmpXJjefnO15M8UexIi6JR2E5thyvsmHyhL6ZDDMUNR4bKJPd4g=="],
+
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 
     "@clack/core": ["@clack/core@1.2.0", "", { "dependencies": { "fast-wrap-ansi": "^0.1.3", "sisteransi": "^1.0.5" } }, "sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg=="],
@@ -91,115 +133,159 @@
 
     "@emmetio/stream-reader-utils": ["@emmetio/stream-reader-utils@0.1.0", "", {}, "sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A=="],
 
-    "@emnapi/runtime": ["@emnapi/runtime@1.8.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg=="],
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
 
-    "@img/colour": ["@img/colour@1.0.0", "", {}, "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.2" }, "os": "darwin", "cpu": "arm64" }, "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.2" }, "os": "darwin", "cpu": "x64" }, "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "os": "freebsd" }, "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg=="],
 
-    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw=="],
 
-    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.2", "", { "os": "linux", "cpu": "arm" }, "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.2", "", { "os": "linux", "cpu": "none" }, "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw=="],
 
-    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.2", "", { "os": "linux", "cpu": "x64" }, "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ=="],
 
-    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.2" }, "os": "linux", "cpu": "arm" }, "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.2" }, "os": "linux", "cpu": "ppc64" }, "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.2" }, "os": "linux", "cpu": "none" }, "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.2" }, "os": "linux", "cpu": "s390x" }, "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA=="],
 
-    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.2" }, "os": "linux", "cpu": "arm64" }, "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.3", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.2" }, "os": "linux", "cpu": "x64" }, "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.3", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.3", "", { "dependencies": { "@img/sharp-wasm32": "0.35.3" }, "cpu": "none" }, "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.3", "", { "os": "win32", "cpu": "x64" }, "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
     "@rollup/pluginutils": ["@rollup/pluginutils@5.3.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q=="],
 
@@ -269,6 +355,8 @@
 
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -317,6 +405,10 @@
 
     "ajv-draft-04": ["ajv-draft-04@1.0.0", "", { "peerDependencies": { "ajv": "^8.5.0" }, "optionalPeers": ["ajv"] }, "sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw=="],
 
+    "ajv-i18n": ["ajv-i18n@4.2.0", "", { "peerDependencies": { "ajv": "^8.0.0-beta.0" } }, "sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg=="],
+
+    "am-i-vibing": ["am-i-vibing@0.4.0", "", { "dependencies": { "process-ancestry": "^0.1.0" }, "bin": { "am-i-vibing": "dist/cli.mjs" } }, "sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -333,7 +425,7 @@
 
     "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
 
-    "astro": ["astro@6.1.9", "", { "dependencies": { "@astrojs/compiler": "^3.0.1", "@astrojs/internal-helpers": "0.9.0", "@astrojs/markdown-remark": "7.1.1", "@astrojs/telemetry": "3.3.1", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^1.1.1", "devalue": "^5.6.3", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.27.3", "flattie": "^1.1.1", "fontace": "~0.4.1", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^0.6.18", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "rehype": "^13.0.2", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "tsconfck": "^3.1.6", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unist-util-visit": "^5.1.0", "unstorage": "^1.17.5", "vfile": "^6.0.3", "vite": "^7.3.2", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0" }, "bin": { "astro": "bin/astro.mjs" } }, "sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ=="],
+    "astro": ["astro@7.1.3", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.1", "@astrojs/internal-helpers": "0.10.1", "@astrojs/markdown-satteri": "0.3.4", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.1.1", "jsonc-parser": "^3.3.1", "magic-string": "^0.30.21", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.1" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-4dhPyAAXthf3xLEYnG8SeL7yr/nTPPABfY7e9YF0yuO+vK9Xp+8Q5j4xzsmL3GueukQv4oNwGNTBepLOiDGeJA=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -371,7 +463,7 @@
 
     "common-ancestor-path": ["common-ancestor-path@2.0.0", "", {}, "sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng=="],
 
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+    "cookie": ["cookie@2.0.1", "", {}, "sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w=="],
 
     "cookie-es": ["cookie-es@1.2.3", "", {}, "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw=="],
 
@@ -397,13 +489,11 @@
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
-    "devalue": ["devalue@5.7.1", "", {}, "sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA=="],
+    "devalue": ["devalue@5.8.2", "", {}, "sha512-DObPPAfdtFbXjxLqK8s2Xk9ZuWz5+ZoFEhC7J76es4GU/rEiXwHTmbImoCdyoCOcBH1UF3+Cz6Z2sYD4hyl5TA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "diff": ["diff@8.0.3", "", {}, "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ=="],
-
-    "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -427,7 +517,7 @@
 
     "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
 
-    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -475,7 +565,7 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
-    "get-tsconfig": ["get-tsconfig@4.13.6", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw=="],
+    "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
 
     "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
@@ -527,21 +617,39 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
-    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
-
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
-
-    "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
-    "jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
-    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -667,9 +775,9 @@
 
     "muggle-string": ["muggle-string@0.4.1", "", {}, "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
-    "neotraverse": ["neotraverse@0.6.18", "", {}, "sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA=="],
+    "neotraverse": ["neotraverse@1.0.1", "", {}, "sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w=="],
 
     "nlcst-to-string": ["nlcst-to-string@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0" } }, "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA=="],
 
@@ -713,11 +821,13 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prismjs": ["prismjs@1.30.0", "", {}, "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw=="],
+
+    "process-ancestry": ["process-ancestry@0.1.0", "", {}, "sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
@@ -738,10 +848,6 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
-
-    "rehype": ["rehype@13.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "rehype-parse": "^9.0.0", "rehype-stringify": "^10.0.0", "unified": "^11.0.0" } }, "sha512-j31mdaRFrwFRUIlxGeuPXXKWQxet52RBQRvCmzl5eCefn/KGbomK5GMHNMsOJf55fgo3qw5tST5neDuarDYR2A=="],
-
-    "rehype-parse": ["rehype-parse@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-from-html": "^2.0.0", "unified": "^11.0.0" } }, "sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag=="],
 
     "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
 
@@ -777,19 +883,23 @@
 
     "retext-stringify": ["retext-stringify@4.0.0", "", { "dependencies": { "@types/nlcst": "^2.0.0", "nlcst-to-string": "^4.0.0", "unified": "^11.0.0" } }, "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA=="],
 
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
     "rollup": ["rollup@4.57.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.57.1", "@rollup/rollup-android-arm64": "4.57.1", "@rollup/rollup-darwin-arm64": "4.57.1", "@rollup/rollup-darwin-x64": "4.57.1", "@rollup/rollup-freebsd-arm64": "4.57.1", "@rollup/rollup-freebsd-x64": "4.57.1", "@rollup/rollup-linux-arm-gnueabihf": "4.57.1", "@rollup/rollup-linux-arm-musleabihf": "4.57.1", "@rollup/rollup-linux-arm64-gnu": "4.57.1", "@rollup/rollup-linux-arm64-musl": "4.57.1", "@rollup/rollup-linux-loong64-gnu": "4.57.1", "@rollup/rollup-linux-loong64-musl": "4.57.1", "@rollup/rollup-linux-ppc64-gnu": "4.57.1", "@rollup/rollup-linux-ppc64-musl": "4.57.1", "@rollup/rollup-linux-riscv64-gnu": "4.57.1", "@rollup/rollup-linux-riscv64-musl": "4.57.1", "@rollup/rollup-linux-s390x-gnu": "4.57.1", "@rollup/rollup-linux-x64-gnu": "4.57.1", "@rollup/rollup-linux-x64-musl": "4.57.1", "@rollup/rollup-openbsd-x64": "4.57.1", "@rollup/rollup-openharmony-arm64": "4.57.1", "@rollup/rollup-win32-arm64-msvc": "4.57.1", "@rollup/rollup-win32-ia32-msvc": "4.57.1", "@rollup/rollup-win32-x64-gnu": "4.57.1", "@rollup/rollup-win32-x64-msvc": "4.57.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A=="],
 
-    "sax": ["sax@1.4.4", "", {}, "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw=="],
+    "satteri": ["satteri@0.9.5", "", { "dependencies": { "@types/estree-jsx": "^1.0.5", "@types/hast": "^3.0.4", "@types/mdast": "^4.0.4", "@types/unist": "^3.0.3" }, "optionalDependencies": { "@bruits/satteri-darwin-arm64": "0.9.5", "@bruits/satteri-darwin-x64": "0.9.5", "@bruits/satteri-linux-arm64-gnu": "0.9.5", "@bruits/satteri-linux-arm64-musl": "0.9.5", "@bruits/satteri-linux-x64-gnu": "0.9.5", "@bruits/satteri-linux-x64-musl": "0.9.5", "@bruits/satteri-wasm32-wasi": "0.9.5", "@bruits/satteri-win32-arm64-msvc": "0.9.5", "@bruits/satteri-win32-x64-msvc": "0.9.5" } }, "sha512-ZuWVl+vnM64y+/TtX8Kosv2c00W+hLQiiwnEL6H0UKVVrxFqMw4D2CJHHQaouVd89OAhtBBfjWLqhKi3TVUV4w=="],
 
-    "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+    "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.35.3", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.5" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.3", "@img/sharp-darwin-x64": "0.35.3", "@img/sharp-freebsd-wasm32": "0.35.3", "@img/sharp-libvips-darwin-arm64": "1.3.2", "@img/sharp-libvips-darwin-x64": "1.3.2", "@img/sharp-libvips-linux-arm": "1.3.2", "@img/sharp-libvips-linux-arm64": "1.3.2", "@img/sharp-libvips-linux-ppc64": "1.3.2", "@img/sharp-libvips-linux-riscv64": "1.3.2", "@img/sharp-libvips-linux-s390x": "1.3.2", "@img/sharp-libvips-linux-x64": "1.3.2", "@img/sharp-libvips-linuxmusl-arm64": "1.3.2", "@img/sharp-libvips-linuxmusl-x64": "1.3.2", "@img/sharp-linux-arm": "0.35.3", "@img/sharp-linux-arm64": "0.35.3", "@img/sharp-linux-ppc64": "0.35.3", "@img/sharp-linux-riscv64": "0.35.3", "@img/sharp-linux-s390x": "0.35.3", "@img/sharp-linux-x64": "0.35.3", "@img/sharp-linuxmusl-arm64": "0.35.3", "@img/sharp-linuxmusl-x64": "0.35.3", "@img/sharp-webcontainers-wasm32": "0.35.3", "@img/sharp-win32-arm64": "0.35.3", "@img/sharp-win32-ia32": "0.35.3", "@img/sharp-win32-x64": "0.35.3" }, "peerDependencies": { "@types/node": "*" }, "optionalPeers": ["@types/node"] }, "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q=="],
 
     "shiki": ["shiki@4.0.2", "", { "dependencies": { "@shikijs/core": "4.0.2", "@shikijs/engine-javascript": "4.0.2", "@shikijs/engine-oniguruma": "4.0.2", "@shikijs/langs": "4.0.2", "@shikijs/themes": "4.0.2", "@shikijs/types": "4.0.2", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ=="],
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
-    "sitemap": ["sitemap@8.0.2", "", { "dependencies": { "@types/node": "^17.0.5", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/cli.js" } }, "sha512-LwktpJcyZDoa0IL6KT++lQ53pbSrx2c9ge41/SeLTyqy2XUNA6uR4+P9u5IVo5lPeL2arAcOKn1aZAxoYbCKlQ=="],
+    "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
 
     "smol-toml": ["smol-toml@1.6.0", "", {}, "sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw=="],
 
@@ -827,11 +937,7 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
-    "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
-
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
-
-    "tsx": ["tsx@4.21.0", "", { "dependencies": { "esbuild": "~0.27.0", "get-tsconfig": "^4.7.5" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw=="],
 
     "typesafe-path": ["typesafe-path@0.2.2", "", {}, "sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA=="],
 
@@ -879,27 +985,27 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "vite": ["vite@7.3.2", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg=="],
+    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
-    "volar-service-css": ["volar-service-css@0.0.68", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-lJSMh6f3QzZ1tdLOZOzovLX0xzAadPhx8EKwraDLPxBndLCYfoTvnNuiFFV8FARrpAlW5C0WkH+TstPaCxr00Q=="],
+    "volar-service-css": ["volar-service-css@0.0.71", "", { "dependencies": { "vscode-css-languageservice": "^6.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw=="],
 
-    "volar-service-emmet": ["volar-service-emmet@0.0.68", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-nHvixrRQ83EzkQ4G/jFxu9Y4eSsXS/X2cltEPDM+K9qZmIv+Ey1w0tg1+6caSe8TU5Hgw4oSTwNMf/6cQb3LzQ=="],
+    "volar-service-emmet": ["volar-service-emmet@0.0.71", "", { "dependencies": { "@emmetio/css-parser": "^0.4.1", "@emmetio/html-matcher": "^1.3.0", "@vscode/emmet-helper": "^2.9.3", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA=="],
 
-    "volar-service-html": ["volar-service-html@0.0.68", "", { "dependencies": { "vscode-html-languageservice": "^5.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-fru9gsLJxy33xAltXOh4TEdi312HP80hpuKhpYQD4O5hDnkNPEBdcQkpB+gcX0oK0VxRv1UOzcGQEUzWCVHLfA=="],
+    "volar-service-html": ["volar-service-html@0.0.71", "", { "dependencies": { "vscode-html-languageservice": "^5.3.0", "vscode-languageserver-textdocument": "^1.0.11", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw=="],
 
-    "volar-service-prettier": ["volar-service-prettier@0.0.68", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0", "prettier": "^2.2 || ^3.0" }, "optionalPeers": ["@volar/language-service", "prettier"] }, "sha512-grUmWHkHlebMOd6V8vXs2eNQUw/bJGJMjekh/EPf/p2ZNTK0Uyz7hoBRngcvGfJHMsSXZH8w/dZTForIW/4ihw=="],
+    "volar-service-prettier": ["volar-service-prettier@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0", "prettier": "^2.2 || ^3.0" }, "optionalPeers": ["@volar/language-service", "prettier"] }, "sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg=="],
 
-    "volar-service-typescript": ["volar-service-typescript@0.0.68", "", { "dependencies": { "path-browserify": "^1.0.1", "semver": "^7.6.2", "typescript-auto-import-cache": "^0.3.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-nls": "^5.2.0", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-z7B/7CnJ0+TWWFp/gh2r5/QwMObHNDiQiv4C9pTBNI2Wxuwymd4bjEORzrJ/hJ5Yd5+OzeYK+nFCKevoGEEeKw=="],
+    "volar-service-typescript": ["volar-service-typescript@0.0.71", "", { "dependencies": { "path-browserify": "^1.0.1", "semver": "^7.6.2", "typescript-auto-import-cache": "^0.3.5", "vscode-languageserver-textdocument": "^1.0.11", "vscode-nls": "^5.2.0", "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw=="],
 
-    "volar-service-typescript-twoslash-queries": ["volar-service-typescript-twoslash-queries@0.0.68", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-NugzXcM0iwuZFLCJg47vI93su5YhTIweQuLmZxvz5ZPTaman16JCvmDZexx2rd5T/75SNuvvZmrTOTNYUsfe5w=="],
+    "volar-service-typescript-twoslash-queries": ["volar-service-typescript-twoslash-queries@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A=="],
 
-    "volar-service-yaml": ["volar-service-yaml@0.0.68", "", { "dependencies": { "vscode-uri": "^3.0.8", "yaml-language-server": "~1.19.2" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-84XgE02LV0OvTcwfqhcSwVg4of3MLNUWPMArO6Aj8YXqyEVnPu8xTEMY2btKSq37mVAPuaEVASI4e3ptObmqcA=="],
+    "volar-service-yaml": ["volar-service-yaml@0.0.71", "", { "dependencies": { "vscode-uri": "^3.0.8", "yaml-language-server": "~1.23.0" }, "peerDependencies": { "@volar/language-service": "~2.4.0" }, "optionalPeers": ["@volar/language-service"] }, "sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q=="],
 
     "vscode-css-languageservice": ["vscode-css-languageservice@6.3.9", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-1tLWfp+TDM5ZuVWht3jmaY5y7O6aZmpeXLoHl5bv1QtRsRKt4xYGRMmdJa5Pqx/FTkgRbsna9R+Gn2xE+evVuA=="],
 
-    "vscode-html-languageservice": ["vscode-html-languageservice@5.6.1", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "^3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-5Mrqy5CLfFZUgkyhNZLA1Ye5g12Cb/v6VM7SxUzZUaRKWMDz4md+y26PrfRTSU0/eQAl3XpO9m2og+GGtDMuaA=="],
+    "vscode-html-languageservice": ["vscode-html-languageservice@5.6.2", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "vscode-languageserver-textdocument": "^1.0.12", "vscode-languageserver-types": "^3.17.5", "vscode-uri": "^3.1.0" } }, "sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg=="],
 
     "vscode-json-languageservice": ["vscode-json-languageservice@4.1.8", "", { "dependencies": { "jsonc-parser": "^3.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-nls": "^5.0.0", "vscode-uri": "^3.0.2" } }, "sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg=="],
 
@@ -919,8 +1025,6 @@
 
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
-    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
-
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "xxhash-wasm": ["xxhash-wasm@1.1.0", "", {}, "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA=="],
@@ -929,7 +1033,7 @@
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
-    "yaml-language-server": ["yaml-language-server@1.19.2", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "lodash": "4.17.21", "prettier": "^3.5.0", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.7.1" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-9F3myNmJzUN/679jycdMxqtydPSDRAarSj3wPiF7pchEPnO9Dg07Oc+gIYLqXR4L+g+FSEVXXv2+mr54StLFOg=="],
+    "yaml-language-server": ["yaml-language-server@1.23.0", "", { "dependencies": { "@vscode/l10n": "^0.0.18", "ajv": "^8.17.1", "ajv-draft-04": "^1.0.0", "ajv-i18n": "^4.2.0", "prettier": "^3.8.1", "request-light": "^0.5.7", "vscode-json-languageservice": "4.1.8", "vscode-languageserver": "^9.0.0", "vscode-languageserver-textdocument": "^1.0.1", "vscode-languageserver-types": "^3.16.0", "vscode-uri": "^3.0.2", "yaml": "2.8.3" }, "bin": { "yaml-language-server": "bin/yaml-language-server" } }, "sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -937,13 +1041,19 @@
 
     "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
-    "@astrojs/language-server/@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
+    "@astrojs/language-server/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "@astrojs/yaml2ts/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@bruits/satteri-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@mdx-js/mdx/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
+
+    "@rolldown/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@rollup/pluginutils/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
@@ -951,9 +1061,9 @@
 
     "@types/sax/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
 
-    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+    "@vscode/emmet-helper/jsonc-parser": ["jsonc-parser@2.3.1", "", {}, "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg=="],
 
-    "astro/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "csso/css-tree": ["css-tree@2.2.1", "", { "dependencies": { "mdn-data": "2.0.28", "source-map-js": "^1.0.1" } }, "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA=="],
 
@@ -961,31 +1071,35 @@
 
     "esast-util-from-js/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
-    "is-inside-container/is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
-
     "micromark-extension-mdxjs/acorn": ["acorn@8.15.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "sitemap/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
-
-    "svgo/sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
+    "sitemap/@types/node": ["@types/node@24.10.13", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "typescript-auto-import-cache/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
     "unstorage/chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "vscode-json-languageservice/jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "yaml-language-server/request-light": ["request-light@0.5.8", "", {}, "sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg=="],
 
-    "yaml-language-server/yaml": ["yaml@2.7.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ=="],
+    "yaml-language-server/yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
 
     "yargs/yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
+
+    "@astrojs/language-server/tinyglobby/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "@types/sax/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "sitemap/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "unstorage/chokidar/readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
 		"@biomejs/biome"
 	],
 	"dependencies": {
-		"@astrojs/check": "^0.9.5",
-		"@astrojs/mdx": "^5.0.3",
-		"@astrojs/sitemap": "^3.6.0",
-		"astro": "^6.1.8",
+		"@astrojs/check": "^0.9.9",
+		"@astrojs/mdx": "^7.0.3",
+		"@astrojs/sitemap": "^3.7.3",
+		"astro": "^7.1.3",
 		"fast-xml-parser": "^5.3.6",
 		"typescript": "^5.9.3",
 		"unist-util-visit": "^5.1.0"
@@ -31,6 +31,6 @@
 		"@biomejs/biome": "2.4.4",
 		"@types/hast": "^3.0.4",
 		"@types/node": "^25.5.0",
-		"sharp": "^0.34.5"
+		"sharp": "^0.35.3"
 	}
 }

--- a/qa/measure.mjs
+++ b/qa/measure.mjs
@@ -61,13 +61,15 @@ for (const [w, h] of [
   [1440, 900],
   [390, 844],
 ]) {
-  const page = await browser.newPage({ viewportSize: { width: w, height: h } });
+  // `viewport`, not `viewportSize` — the latter is silently ignored by newPage
+  // and every shot comes out at Chrome's default 1280.
+  const page = await browser.newPage({ viewport: { width: w, height: h } });
   await page.goto(url, { waitUntil: 'networkidle' });
   if (debugOutline) {
     await page.addStyleTag({ content: '* { outline: 1px solid rgba(255,0,0,.4) !important; }' });
   }
   await page.screenshot({ path: `qa/screenshots/${label}-${w}.png`, fullPage: true });
-  if (w === 1440) rows.push(...(await page.evaluate(COLLECT)));
+  rows.push([w, await page.evaluate(COLLECT)]);
   await page.close();
 }
 
@@ -76,29 +78,30 @@ await browser.close();
 // The colour edge between two blocks is the top of the lower one: adjacent
 // siblings share it, and where a wrapper sits between them (header/main) the
 // lower block's own top is still where its background starts.
-console.log(`\n${label} @1440 — seam bisection (target 96 / 96)\n`);
-console.log('seam                       above  below  total  bisected');
-for (let i = 0; i < rows.length - 1; i++) {
-  const a = rows[i];
-  const b = rows[i + 1];
-  const edge = b.top;
-  const above = edge - a.contentBottom;
-  const below = b.contentTop - edge;
-  const ok = above === 96 && below === 96;
-  console.log(
-    `${`${a.name} -> ${b.name}`.padEnd(26)} ${String(above).padStart(5)}  ${String(below).padStart(5)}  ${String(above + below).padStart(5)}  ${ok ? 'yes' : 'NO'}`,
-  );
-}
+// --space-section steps down at 768px, so the target does too.
+for (const [w, blocks] of rows) {
+  const target = w <= 768 ? 56 : 96;
+  console.log(`\n${label} @${w} — seam bisection (target ${target} / ${target})\n`);
+  console.log('seam                       above  below  total  bisected');
+  for (let i = 0; i < blocks.length - 1; i++) {
+    const a = blocks[i];
+    const b = blocks[i + 1];
+    const edge = b.top;
+    const above = edge - a.contentBottom;
+    const below = b.contentTop - edge;
+    const ok = above === target && below === target;
+    console.log(
+      `${`${a.name} -> ${b.name}`.padEnd(26)} ${String(above).padStart(5)}  ${String(below).padStart(5)}  ${String(above + below).padStart(5)}  ${ok ? 'yes' : 'NO'}`,
+    );
+  }
 
-// Content escaping its own block means a child margin or overflow is driving the
-// seam, not the section padding — the seam numbers above cannot be trusted until
-// it is gone.
-const overflow = rows.filter((r) => r.contentBottom > r.bottom || r.contentTop < r.top);
-if (overflow.length) {
-  console.log('\noverflowing blocks (content outside the block box):');
+  // Content escaping its own block means a child margin or overflow is driving
+  // the seam, not the section padding — the numbers above cannot be trusted
+  // until it is gone.
+  const overflow = blocks.filter((r) => r.contentBottom > r.bottom || r.contentTop < r.top);
   for (const r of overflow) {
     console.log(
-      `  ${r.name.padEnd(10)} box ${r.top}..${r.bottom}   content ${r.contentTop}..${r.contentBottom}`,
+      `  overflow: ${r.name} box ${r.top}..${r.bottom}, content ${r.contentTop}..${r.contentBottom}`,
     );
   }
 }

--- a/qa/measure.mjs
+++ b/qa/measure.mjs
@@ -1,0 +1,104 @@
+// Seam audit + screenshots. Run: bunx --bun playwright ... no — plain node/bun:
+//   bun qa/measure.mjs <url> <label>
+// Writes qa/screenshots/<label>-{1440,390}.png and prints the seam table.
+import { chromium } from 'playwright';
+
+const url = process.argv[2] ?? 'http://localhost:4321/';
+const label = process.argv[3] ?? 'shot';
+const debugOutline = process.argv.includes('--outline');
+
+// Each block is a background region; the seam between two is where the colour
+// can change, so the boundary is always the shared edge of adjacent siblings.
+const COLLECT = `(() => {
+  const blocks = [];
+  const push = (el, name) => { if (el) blocks.push([el, name]); };
+  push(document.querySelector('header'), 'header');
+  const shell = document.querySelector('.page-shell');
+  const names = ['hero', 'map', 'quest', 'listen', 'arcane', 'party'];
+  [...shell.children].forEach((el, i) => push(el, names[i] ?? 'block' + i));
+  push(document.querySelector('footer'), 'footer');
+
+  // Extremes of painted content, so margins and wrapper padding are counted as gap.
+  const extremes = (root) => {
+    // Visually-hidden wrappers still lay their children out at full size, so a
+    // screen-reader-only list reports a rect hundreds of pixels past the section.
+    // Collect the clipped wrappers first and skip everything inside them.
+    const clipped = [...root.querySelectorAll('*')].filter((el) => {
+      const s = getComputedStyle(el);
+      return s.clip === 'rect(0px, 0px, 0px, 0px)' || s.clipPath === 'inset(50%)';
+    });
+    let top = Infinity, bottom = -Infinity;
+    for (const el of root.querySelectorAll('*')) {
+      const r = el.getBoundingClientRect();
+      if (r.width < 2 || r.height < 2) continue;
+      const s = getComputedStyle(el);
+      if (s.visibility === 'hidden' || s.opacity === '0') continue;
+      if (clipped.some((c) => c.contains(el))) continue;
+      top = Math.min(top, r.top); bottom = Math.max(bottom, r.bottom);
+    }
+    return { top, bottom };
+  };
+
+  return blocks.map(([el, name]) => {
+    const r = el.getBoundingClientRect();
+    const e = extremes(el);
+    return {
+      name,
+      top: Math.round(r.top + scrollY),
+      bottom: Math.round(r.bottom + scrollY),
+      contentTop: Math.round(e.top + scrollY),
+      contentBottom: Math.round(e.bottom + scrollY),
+      bg: getComputedStyle(el).backgroundColor,
+    };
+  });
+})()`;
+
+// System Chrome, so this needs no bundled-browser download.
+const browser = await chromium.launch({ channel: 'chrome' });
+const rows = [];
+
+for (const [w, h] of [
+  [1440, 900],
+  [390, 844],
+]) {
+  const page = await browser.newPage({ viewportSize: { width: w, height: h } });
+  await page.goto(url, { waitUntil: 'networkidle' });
+  if (debugOutline) {
+    await page.addStyleTag({ content: '* { outline: 1px solid rgba(255,0,0,.4) !important; }' });
+  }
+  await page.screenshot({ path: `qa/screenshots/${label}-${w}.png`, fullPage: true });
+  if (w === 1440) rows.push(...(await page.evaluate(COLLECT)));
+  await page.close();
+}
+
+await browser.close();
+
+// The colour edge between two blocks is the top of the lower one: adjacent
+// siblings share it, and where a wrapper sits between them (header/main) the
+// lower block's own top is still where its background starts.
+console.log(`\n${label} @1440 — seam bisection (target 96 / 96)\n`);
+console.log('seam                       above  below  total  bisected');
+for (let i = 0; i < rows.length - 1; i++) {
+  const a = rows[i];
+  const b = rows[i + 1];
+  const edge = b.top;
+  const above = edge - a.contentBottom;
+  const below = b.contentTop - edge;
+  const ok = above === 96 && below === 96;
+  console.log(
+    `${`${a.name} -> ${b.name}`.padEnd(26)} ${String(above).padStart(5)}  ${String(below).padStart(5)}  ${String(above + below).padStart(5)}  ${ok ? 'yes' : 'NO'}`,
+  );
+}
+
+// Content escaping its own block means a child margin or overflow is driving the
+// seam, not the section padding — the seam numbers above cannot be trusted until
+// it is gone.
+const overflow = rows.filter((r) => r.contentBottom > r.bottom || r.contentTop < r.top);
+if (overflow.length) {
+  console.log('\noverflowing blocks (content outside the block box):');
+  for (const r of overflow) {
+    console.log(
+      `  ${r.name.padEnd(10)} box ${r.top}..${r.bottom}   content ${r.contentTop}..${r.contentBottom}`,
+    );
+  }
+}

--- a/src/components/CastleSceneRetro.astro
+++ b/src/components/CastleSceneRetro.astro
@@ -35,6 +35,43 @@ const Merlon = (x: number, y: number) => ({
 	shadow: { x: x + 2, y: y + 2, width: 4, height: 20 }, // Left face
 });
 
+// Hanging signboard behind each section label. Press Start 2P advances one em
+// per glyph, so at font-size 16 a label is chars*16 wide; +32 padding keeps the
+// plaque and its half-width on the 8px grid. Height 32 puts the baseline 8px up
+// from the lower edge.
+const SIGN_GAP = 16;
+const Sign = (cx: number, structureTop: number, chars: number) => ({
+	plate: {
+		x: cx - (chars * 16 + 32) / 2,
+		y: structureTop - SIGN_GAP - 32,
+		width: chars * 16 + 32,
+		height: 32,
+	},
+	text: { x: cx, y: structureTop - SIGN_GAP - 8 },
+});
+
+// One placement rule for all six: the plaque's bottom edge hangs SIGN_GAP above
+// the top of the silhouette it labels. Silhouette means masonry and flag pole -
+// animated FX (smoke, moon glow) pass behind the sign rather than pushing it up.
+const SIGNS = {
+	talks: Sign(240, 72, 5), // tower flag pole
+	blog: Sign(460, 132, 4), // library flag pole
+	about: Sign(720, 88, 5), // keep flag pole
+	code: Sign(960, 200, 4), // forge chimney
+	shorts: Sign(1080, 80, 6), // moon disc
+	listen: Sign(1096, 520, 6), // podcast scroll
+};
+
+// Mobile navigation chips - same six destinations as the drawn buildings.
+const CHIPS = [
+	{ href: '/talks/', label: 'Talks', section: 'Tower' },
+	{ href: '/blog/', label: 'Blog', section: 'Library' },
+	{ href: '/forge/', label: 'Code', section: 'Forge' },
+	{ href: '/shorts/', label: 'Shorts', section: 'Shorts' },
+	{ href: '/about/', label: 'About', section: 'Keep' },
+	{ href: '/#listen', label: 'Listen', section: 'Podcast' },
+];
+
 // Brick pattern - stepped pixel blocks
 const BrickRow = (x: number, y: number, width: number, offset = 0) => {
 	const bricks: Array<{ x: number; y: number; width: number; height: number }> = [];
@@ -55,7 +92,7 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
 <svg
   xmlns="http://www.w3.org/2000/svg"
   viewBox="0 0 1200 600"
-  role="img"
+  role="group"
   aria-labelledby={`${uid}-title`} aria-describedby={`${uid}-desc`}
   class="castle-scene-retro"
 >
@@ -148,24 +185,18 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
       <rect x="1062" y="122" width="6" height="4" fill="var(--colour-forge-orange)" opacity="0.3" />
       <rect x="1092" y="122" width="6" height="4" fill="var(--colour-forge-orange)" opacity="0.3" />
 
-      <!-- Moon label (always visible, like other sections) -->
+      <!-- Signboard -->
+      <rect
+        {...SIGNS.shorts.plate}
+        class="sign-plate"
+        shape-rendering="crispEdges"></rect>
       <text
-        x="1080"
-        y="184"
+        {...SIGNS.shorts.text}
+        class="sign-label"
         text-anchor="middle"
-        fill="var(--colour-parchment)"
         font-family="'Press Start 2P', monospace"
-        font-size="11"
+        font-size="16"
         letter-spacing="1">SHORTS</text>
-      <text
-        x="1080"
-        y="198"
-        text-anchor="middle"
-        fill="var(--colour-parchment)"
-        font-family="'Press Start 2P', monospace"
-        font-size="7"
-        opacity="0"
-        class="castle-subtitle">The Moon</text>
     </g>
   </a>
 
@@ -405,7 +436,7 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         ].map((w) => (
           <g class="window-flicker">
             <rect {...w.outer} fill="var(--colour-black)" opacity="0.4" />
-            <rect {...w.light} fill="var(--colour-gold)" opacity="0.85" />
+            <rect {...w.light} class="window-light" fill="var(--colour-gold)" opacity="0.85" />
             <rect {...w.crossV} fill="var(--colour-stone-dark)" opacity="0.6" />
             <rect {...w.crossH} fill="var(--colour-stone-dark)" opacity="0.6" />
             <rect {...w.highlight} fill="var(--colour-white)" opacity="0.2" />
@@ -413,25 +444,18 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         ))
       }
 
-      <!-- Label -->
+      <!-- Signboard -->
+      <rect
+        {...SIGNS.talks.plate}
+        class="sign-plate"
+        shape-rendering="crispEdges"></rect>
       <text
-        x="240"
-        y="88"
+        {...SIGNS.talks.text}
+        class="sign-label"
         text-anchor="middle"
-        fill="var(--colour-parchment)"
         font-family="'Press Start 2P', monospace"
-        font-size="11"
-        letter-spacing="1">TALKS</text
-      >
-      <text
-        x="240"
-        y="102"
-        text-anchor="middle"
-        fill="var(--colour-parchment)"
-        font-family="'Press Start 2P', monospace"
-        font-size="7"
-        opacity="0"
-        class="castle-subtitle">The Tower</text>
+        font-size="16"
+        letter-spacing="1">TALKS</text>
 
       <!-- Hover sparkles -->
       <g class="hover-sparkle" opacity="0">
@@ -585,7 +609,7 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         ].map((w) => (
           <g class="window-flicker">
             <rect {...w.outer} fill="var(--colour-black)" opacity="0.4" />
-            <rect {...w.light} fill="var(--colour-gold)" opacity="0.85" />
+            <rect {...w.light} class="window-light" fill="var(--colour-gold)" opacity="0.85" />
             <rect {...w.crossV} fill="var(--colour-stone-dark)" opacity="0.6" />
             <rect {...w.crossH} fill="var(--colour-stone-dark)" opacity="0.6" />
             <rect {...w.highlight} fill="var(--colour-white)" opacity="0.2" />
@@ -657,25 +681,18 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         ></rect>
       </g>
 
-      <!-- Label -->
+      <!-- Signboard -->
+      <rect
+        {...SIGNS.blog.plate}
+        class="sign-plate"
+        shape-rendering="crispEdges"></rect>
       <text
-        x="460"
-        y="168"
+        {...SIGNS.blog.text}
+        class="sign-label"
         text-anchor="middle"
-        fill="var(--colour-parchment)"
         font-family="'Press Start 2P', monospace"
-        font-size="11"
-        letter-spacing="1">BLOG</text
-      >
-      <text
-        x="460"
-        y="182"
-        text-anchor="middle"
-        fill="var(--colour-parchment)"
-        font-family="'Press Start 2P', monospace"
-        font-size="7"
-        opacity="0"
-        class="castle-subtitle">The Library</text>
+        font-size="16"
+        letter-spacing="1">BLOG</text>
 
       <!-- Hover sparkles -->
       <g class="hover-sparkle" opacity="0">
@@ -871,7 +888,7 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
       ].map((w) => (
         <g class="window-flicker">
           <rect {...w.outer} fill="var(--colour-black)" opacity="0.4" />
-          <rect {...w.light} fill="var(--colour-gold)" opacity="0.85" />
+          <rect {...w.light} class="window-light" fill="var(--colour-gold)" opacity="0.85" />
           <rect {...w.crossV} fill="var(--colour-stone-dark)" opacity="0.6" />
           <rect {...w.crossH} fill="var(--colour-stone-dark)" opacity="0.6" />
           <rect {...w.highlight} fill="var(--colour-white)" opacity="0.2" />
@@ -943,24 +960,18 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         fill="var(--colour-gold)"
         opacity="0"
         class="section-glow"></rect>
-      <!-- About label + keyboard/hover reveal affordances -->
+      <!-- Signboard -->
+      <rect
+        {...SIGNS.about.plate}
+        class="sign-plate"
+        shape-rendering="crispEdges"></rect>
       <text
-        x="720"
-        y="404"
+        {...SIGNS.about.text}
+        class="sign-label"
         text-anchor="middle"
-        fill="var(--colour-parchment)"
         font-family="'Press Start 2P', monospace"
-        font-size="11"
+        font-size="16"
         letter-spacing="1">ABOUT</text>
-      <text
-        x="720"
-        y="418"
-        text-anchor="middle"
-        fill="var(--colour-parchment)"
-        font-family="'Press Start 2P', monospace"
-        font-size="7"
-        opacity="0"
-        class="castle-subtitle">The Keep</text>
       <g class="hover-sparkle" opacity="0">
         <rect x="600" y="152" width="4" height="4" fill="var(--colour-gold)" />
         <rect x="840" y="152" width="4" height="4" fill="var(--colour-gold)" />
@@ -1336,25 +1347,18 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         fill="var(--colour-grass)"
         opacity="0.12"></ellipse>
 
-      <!-- Label -->
+      <!-- Signboard -->
+      <rect
+        {...SIGNS.code.plate}
+        class="sign-plate"
+        shape-rendering="crispEdges"></rect>
       <text
-        x="960"
-        y="248"
+        {...SIGNS.code.text}
+        class="sign-label"
         text-anchor="middle"
-        fill="var(--colour-parchment)"
         font-family="'Press Start 2P', monospace"
-        font-size="11"
-        letter-spacing="1">CODE</text
-      >
-      <text
-        x="960"
-        y="262"
-        text-anchor="middle"
-        fill="var(--colour-parchment)"
-        font-family="'Press Start 2P', monospace"
-        font-size="7"
-        opacity="0"
-        class="castle-subtitle">The Forge</text>
+        font-size="16"
+        letter-spacing="1">CODE</text>
 
       <!-- Hover sparkles -->
       <g class="hover-sparkle" opacity="0">
@@ -1431,28 +1435,20 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         fill="var(--colour-parchment)"
         font-family="'Press Start 2P', monospace"
         font-size="12"
-        font-weight="700">S</text
-      >
+        font-weight="700">S</text>
 
-      <!-- Label -->
+      <!-- Signboard -->
+      <rect
+        {...SIGNS.listen.plate}
+        class="sign-plate"
+        shape-rendering="crispEdges"></rect>
       <text
-        x="1096"
-        y="512"
+        {...SIGNS.listen.text}
+        class="sign-label"
         text-anchor="middle"
-        fill="var(--colour-parchment)"
         font-family="'Press Start 2P', monospace"
-        font-size="9"
-        letter-spacing="1">LISTEN</text
-      >
-      <text
-        x="1096"
-        y="526"
-        text-anchor="middle"
-        fill="var(--colour-parchment)"
-        font-family="'Press Start 2P', monospace"
-        font-size="7"
-        opacity="0"
-        class="castle-subtitle">Podcast</text>
+        font-size="16"
+        letter-spacing="1">LISTEN</text>
 
       <!-- Hover sparkles -->
       <g class="hover-sparkle" opacity="0">
@@ -1491,6 +1487,25 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
   <rect x="896" y="490" width="128" height="8" fill="var(--colour-black)" opacity="0.15" />
 </svg>
 
+<!-- Same six destinations as the signboards. Below 640px the scene is inert
+     decoration and these chips are the visible navigation; above it they are the
+     visually-hidden link list, so the wayfinding survives however you read it. -->
+<ul class="castle-chips">
+  {
+    CHIPS.map((chip: { href: string; label: string; section: string }) => (
+      <li>
+        <a
+          href={chip.href}
+          class="castle-chip pixel-eyebrow notched"
+          data-castle-nav={chip.section}
+        >
+          {chip.label}
+        </a>
+      </li>
+    ))
+  }
+</ul>
+
 <style>
   .castle-scene-retro {
     width: 100%;
@@ -1498,6 +1513,9 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
     max-width: var(--max-width-wide);
     display: block;
     shape-rendering: crispEdges;
+    /* The scroll and its sparkles sit on the viewBox's bottom edge, so the SVG
+       viewport would otherwise clip that anchor's focus ring. */
+    overflow: visible;
   }
 
   @supports (image-rendering: pixelated) {
@@ -1529,10 +1547,6 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
     opacity: 0.25;
   }
 
-  .castle-scene-retro a:focus-visible .castle-subtitle {
-    opacity: 0.7;
-  }
-
   .castle-scene-retro a:focus-visible .hover-sparkle {
     opacity: 1;
     animation: sparkle-pop 0.6s steps(3, end);
@@ -1543,28 +1557,44 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
     animation-play-state: paused !important;
   }
 
+  /* Signboard: SVG text has no background, so the plaque is a rect drawn just
+     before each label. Visible at rest — gold on navy reads as a sign, and a
+     sign reads as clickable where floating text does not (6.8:1 either way). */
+  .sign-plate {
+    fill: var(--colour-teal-dark);
+    stroke: var(--colour-gold);
+    stroke-width: 1;
+  }
+
+  .sign-label {
+    fill: var(--colour-gold);
+  }
+
+  /* Hover/focus inverts the sign. Instant swap, not a fade — the hard cut suits
+     the pixel art and leaves nothing to gate on reduced motion. */
+  .castle-section:hover .sign-plate,
+  .castle-scene-retro a:focus-visible .sign-plate {
+    fill: var(--colour-gold);
+  }
+
+  .castle-section:hover .sign-label,
+  .castle-scene-retro a:focus-visible .sign-label {
+    fill: var(--colour-teal-dark);
+  }
+
+  /* Lights up one step: the building reads as "open" under the cursor */
+  .castle-section:hover .window-light,
+  .castle-scene-retro a:focus-visible .window-light {
+    fill: var(--colour-gold-light);
+    opacity: 1;
+  }
+
   .section-glow {
     transition: opacity 0.25s ease-in-out;
   }
 
   .castle-section:hover .section-glow {
     opacity: 0.25;
-  }
-
-  .castle-label {
-    transition: opacity 0.25s ease-in-out;
-  }
-
-  .castle-section:hover .castle-label {
-    opacity: 1;
-  }
-
-  .castle-subtitle {
-    transition: opacity 0.25s ease-in-out;
-  }
-
-  .castle-section:hover .castle-subtitle {
-    opacity: 0.7;
   }
 
   .hover-sparkle {
@@ -1897,16 +1927,66 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
     }
   }
 
-  /* Mobile: castle becomes a decorative banner */
-  @media (max-width: 768px) {
-    .castle-scene-retro {
-      max-height: 180px;
+  .castle-chips {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2);
+    list-style: none;
+    margin: var(--space-4) 0 0;
+    padding: 0;
+  }
+
+  .castle-chip {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    /* WCAG 2.5.8 target size */
+    min-height: 44px;
+    min-width: 44px;
+    padding: 0 var(--space-3);
+    border: 2px solid var(--colour-gold);
+    background: var(--colour-teal-dark);
+    text-decoration: none;
+  }
+
+  .castle-chip:hover,
+  .castle-chip:focus-visible {
+    background: var(--colour-gold);
+    color: var(--colour-teal-dark);
+  }
+
+  .castle-chip:focus-visible {
+    outline: 3px solid var(--colour-parchment);
+    outline-offset: 2px;
+  }
+
+  /* Above the breakpoint the castle's own six anchors are the visible nav, so the
+     list is present for screen readers but hidden — and revealed on focus, so a
+     sighted keyboard user never lands on an invisible tab stop. Inlined rather
+     than reusing .sr-only because the hiding has to be conditional. */
+  @media (min-width: 640px) {
+    .castle-chips:not(:focus-within) {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
       overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+    }
+  }
+
+  /* Below 640px the castle is decoration only: at that width its 16px signs
+     render around 5px, and the inline script takes the scene out of the tab
+     order and the accessibility tree. The chips carry the navigation instead. */
+  @media (max-width: 639px) {
+    .castle-scene-retro {
       pointer-events: none;
     }
 
     .castle-section text,
-    .castle-subtitle {
+    .sign-plate {
       display: none;
     }
   }
@@ -1917,10 +1997,6 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
     }
     .castle-section:hover {
       transform: none;
-    }
-    .section-glow,
-    .castle-subtitle {
-      transition: none;
     }
     .window-flicker,
     .forge-glow-animation,
@@ -1954,6 +2030,25 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
       }
     });
   });
+</script>
+
+<script is:inline>
+  // Below 640px the scene is a decorative banner: its labels are hidden, so take the
+  // whole thing out of the tab order rather than leave six invisible stops for
+  // keyboard and screen reader users. The .castle-chips list takes over there, and
+  // the breakpoint must stay in step with the media query above or a viewport width
+  // exists with no navigation at all.
+  (function () {
+    var scene = document.querySelector('.castle-scene-retro');
+    if (!scene) return;
+    var mobile = window.matchMedia('(max-width: 639px)');
+    var apply = function () {
+      scene.inert = mobile.matches;
+      scene.setAttribute('aria-hidden', String(mobile.matches));
+    };
+    mobile.addEventListener('change', apply);
+    apply();
+  })();
 </script>
 
 <script is:inline>

--- a/src/components/CastleSceneRetro.astro
+++ b/src/components/CastleSceneRetro.astro
@@ -40,26 +40,28 @@ const Merlon = (x: number, y: number) => ({
 // plaque and its half-width on the 8px grid. Height 32 puts the baseline 8px up
 // from the lower edge.
 const SIGN_GAP = 16;
-const Sign = (cx: number, structureTop: number, chars: number) => ({
+const Sign = (cx: number, roofline: number, chars: number) => ({
 	plate: {
 		x: cx - (chars * 16 + 32) / 2,
-		y: structureTop - SIGN_GAP - 32,
+		y: roofline - SIGN_GAP - 32,
 		width: chars * 16 + 32,
 		height: 32,
 	},
-	text: { x: cx, y: structureTop - SIGN_GAP - 8 },
+	text: { x: cx, y: roofline - SIGN_GAP - 8 },
 });
 
-// One placement rule for all six: the plaque's bottom edge hangs SIGN_GAP above
-// the top of the silhouette it labels. Silhouette means masonry and flag pole -
-// animated FX (smoke, moon glow) pass behind the sign rather than pushing it up.
+// One rule for all six: the plaque's bottom edge sits exactly SIGN_GAP above the
+// roofline of the thing it labels. Roofline means topmost masonry, measured off
+// the art below - not the flagpole above it, which is why the three flags were
+// raised to fly clear of their signs. Animated FX (chimney smoke, moon glow) pass
+// behind the plaque rather than pushing it up.
 const SIGNS = {
-	talks: Sign(240, 72, 5), // tower flag pole
-	blog: Sign(460, 132, 4), // library flag pole
-	about: Sign(720, 88, 5), // keep flag pole
-	code: Sign(960, 200, 4), // forge chimney
-	shorts: Sign(1080, 80, 6), // moon disc
-	listen: Sign(1096, 520, 6), // podcast scroll
+	talks: Sign(240, 96, 5), // tower battlements, Merlon y 96
+	blog: Sign(460, 180, 4), // library dome apex, y 180
+	about: Sign(720, 136, 5), // keep crenellations, Merlon y 136
+	code: Sign(960, 200, 4), // forge chimney housing, y 200
+	shorts: Sign(1080, 80, 6), // moon disc top, cy 120 - r 40
+	listen: Sign(1096, 520, 6), // podcast scroll, y 520
 };
 
 // Mobile navigation chips - same six destinations as the drawn buildings.
@@ -388,17 +390,18 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         ))
       }
 
-      <!-- Tower flag (animated) -->
-      <rect x="236" y="72" width="8" height="48" fill="var(--colour-stone-dark)"
+      <!-- Tower flag (animated). Pole lengthened so the pennant flies 12 above the
+           signboard; the plaque occludes the stretch it crosses. -->
+      <rect x="236" y="16" width="8" height="104" fill="var(--colour-stone-dark)"
       ></rect>
       <path
-        d="M 244 76 L 268 84 L 244 92 Z"
+        d="M 244 20 L 268 28 L 244 36 Z"
         fill="var(--colour-gold)"
         stroke="var(--colour-gold-dark)"
         stroke-width="1"
         class="flag-wave"></path>
       <path
-        d="M 244 76 L 268 84 L 244 92 Z"
+        d="M 244 20 L 268 28 L 244 36 Z"
         fill="var(--colour-gold-dark)"
         opacity="0.3"
         transform="translate(2, 2)"></path>
@@ -521,22 +524,22 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
         ))
       }
 
-      <!-- Library flag -->
+      <!-- Library flag. Pole lengthened to clear the signboard by 12. -->
       <rect
         x="456"
-        y="132"
+        y="100"
         width="8"
-        height="48"
+        height="80"
         fill="var(--colour-stone-dark)"></rect>
       <path
-        d="M 464 136 L 488 144 L 464 152 Z"
+        d="M 464 104 L 488 112 L 464 120 Z"
         fill="var(--colour-gold)"
         stroke="var(--colour-gold-dark)"
         stroke-width="1"
         class="flag-wave"
         style="animation-delay: 0.5s"></path>
       <path
-        d="M 464 136 L 488 144 L 464 152 Z"
+        d="M 464 104 L 488 112 L 464 120 Z"
         fill="var(--colour-gold-dark)"
         opacity="0.3"
         transform="translate(2, 2)"></path>
@@ -774,18 +777,18 @@ const BrickRow = (x: number, y: number, width: number, offset = 0) => {
       ))
     }
 
-    <!-- Keep flag (tallest) -->
-    <rect x="716" y="88" width="8" height="72" fill="var(--colour-stone-dark)"
+    <!-- Keep flag (tallest). Pole lengthened to clear the signboard by 12. -->
+    <rect x="716" y="48" width="8" height="112" fill="var(--colour-stone-dark)"
     ></rect>
     <path
-      d="M 724 92 L 756 104 L 724 116 Z"
+      d="M 724 52 L 756 64 L 724 76 Z"
       fill="var(--colour-gold)"
       stroke="var(--colour-gold-dark)"
       stroke-width="1"
       class="flag-wave"
       style="animation-delay: 0.3s"></path>
     <path
-      d="M 724 92 L 756 104 L 724 116 Z"
+      d="M 724 52 L 756 64 L 724 76 Z"
       fill="var(--colour-gold-dark)"
       opacity="0.3"
       transform="translate(2, 2)"></path>

--- a/src/components/CredibilityStrip.astro
+++ b/src/components/CredibilityStrip.astro
@@ -7,7 +7,7 @@ export interface Props {
 const { itemCount } = Astro.props;
 ---
 
-<p class="cred-strip">
+<p class="cred-strip pixel-diamond">
 	<span class="cred-strip__item">
 		<a href="/about/">Chris Lloyd-Jones &amp; Josh McDonald</a>
 	</span>
@@ -42,9 +42,10 @@ const { itemCount } = Astro.props;
 		color: var(--colour-gold-light);
 	}
 
-	.cred-strip__item:not(:last-child)::after {
-		content: '·';
-		margin-left: var(--space-3);
-		color: var(--colour-stone-dark);
+	/* Separator comes from the .pixel-diamond utility; the gap is even either
+	   side because the flex gap supplies the leading space and the glyph's own
+	   margin supplies the trailing one. */
+	.cred-strip {
+		gap: var(--space-3);
 	}
 </style>

--- a/src/components/CredibilityStrip.astro
+++ b/src/components/CredibilityStrip.astro
@@ -1,41 +1,50 @@
 ---
 export interface Props {
-	talkCount: number;
+	/** Talks and videos actually published, not a rounded-up claim. */
+	itemCount: number;
 }
 
-const { talkCount } = Astro.props;
-const items = [
-	'Hosted by two Microsoft MVPs',
-	`${talkCount}+ talks & videos`,
-	'Listen on Spotify, Apple & YouTube',
-];
+const { itemCount } = Astro.props;
 ---
 
 <p class="cred-strip">
-	{items.map((item: string) => <span class="cred-strip__item">{item}</span>)}
+	<span class="cred-strip__item">
+		<a href="/about/">Chris Lloyd-Jones &amp; Josh McDonald</a>
+	</span>
+	<span class="cred-strip__item">Microsoft MVPs</span>
+	<span class="cred-strip__item">{itemCount} talks and videos</span>
 </p>
 
 <style>
+	/* No border: the bar sits directly under the primary CTA and must not compete with it */
 	.cred-strip {
 		display: flex;
 		flex-wrap: wrap;
-		align-items: center;
-		justify-content: center;
+		row-gap: 0;
+		align-items: baseline;
 		gap: var(--space-2) var(--space-3);
-		width: fit-content;
 		max-width: 100%;
-		margin-inline: auto;
-		padding: var(--space-2) var(--space-4);
-		border: 2px solid var(--colour-gold);
-		border-radius: var(--radius-sm);
-		color: var(--colour-gold);
+		margin: 0;
+		color: var(--colour-stone-light);
 		font-size: var(--font-size-sm);
 		font-family: var(--font-body);
 	}
 
-	.cred-strip__item:not(:first-child)::before {
-		content: '·';
-		margin-right: var(--space-3);
+	.cred-strip a {
 		color: var(--colour-gold);
+		text-decoration: underline;
+		text-decoration-thickness: 1px;
+		text-underline-offset: 2px;
+	}
+
+	.cred-strip a:hover,
+	.cred-strip a:focus-visible {
+		color: var(--colour-gold-light);
+	}
+
+	.cred-strip__item:not(:last-child)::after {
+		content: '·';
+		margin-left: var(--space-3);
+		color: var(--colour-stone-dark);
 	}
 </style>

--- a/src/components/EpisodePoster.astro
+++ b/src/components/EpisodePoster.astro
@@ -35,21 +35,21 @@ const a11y: Record<string, string> = decorative
 <div class:list={['poster', `poster--${variant}`]} data-realm={realm} {...a11y}>
 	{variant === 'poster' && <p class="pixel-eyebrow poster__source">{source}</p>}
 	{variant === 'poster' && <p class="poster__title">{title}</p>}
-	<div class="poster__foot">
-		{/* Category glyph, not the show shield: the shield is already in the header,
-		    and the thumbnail should say what the episode is. */}
-		<span class="poster__mark">
-			{realm === 'tower' && <TowerIcon />}
-			{realm === 'library' && <LibraryIcon />}
-			{realm === 'forge' && <ForgeIcon />}
-			{realm === 'moon' && <MoonIcon />}
-		</span>
-	</div>
+	{/* Category glyph, not the show shield: the shield is already in the header,
+	    and the thumbnail should say what the episode is. */}
+	<span class="poster__mark">
+		{realm === 'tower' && <TowerIcon />}
+		{realm === 'library' && <LibraryIcon />}
+		{realm === 'forge' && <ForgeIcon />}
+		{realm === 'moon' && <MoonIcon />}
+	</span>
 </div>
 
 <style>
 	.poster {
 		container-type: inline-size;
+		/* Containing block for the centred card glyph */
+		position: relative;
 		/* inline-size containment makes the intrinsic width 0, so a flex parent
 		   would shrink this to nothing and aspect-ratio would give it 0 height */
 		width: 100%;
@@ -100,29 +100,33 @@ const a11y: Record<string, string> = decorative
 		overflow: hidden;
 	}
 
+	/* Block, so no baseline gap pads the box below the glyph and shifts its
+	   optical centre off the tile's centre */
 	.poster__mark :global(svg) {
+		display: block;
 		width: 100%;
 		height: auto;
 	}
 
-	.poster__foot {
-		display: flex;
-		align-items: flex-end;
-		justify-content: space-between;
-		gap: var(--space-3);
-	}
-
-	.poster__date {
-		font-family: var(--font-body);
-		font-size: min(var(--font-size-sm), 3.5cqi);
-		color: var(--colour-parchment);
-	}
-
 	.poster__mark {
 		display: block;
-		width: clamp(var(--space-8), 10cqi, var(--space-16));
-		height: auto;
-		margin-inline-start: auto;
+		/* Floor and ceiling are the 48-64px target band, so the glyph stays in
+		   it at any card width the container query units would otherwise miss */
+		width: clamp(var(--space-12), 13cqi, var(--space-16));
+		/* Poster variant only: the baked title owns the middle, so the glyph
+		   sits bottom-right of it (last grid row) */
+		justify-self: end;
 		image-rendering: pixelated;
+	}
+
+	/* Card variant bakes in no text, so the glyph takes the centre of the tile.
+	   Positioned rather than laid out: VideoFacade forces display:block on the
+	   slotted poster, so the grid above does not apply inside the hero. The
+	   square ratio gives the auto margins a definite height to centre. */
+	.poster--card .poster__mark {
+		position: absolute;
+		inset: 0;
+		margin: auto;
+		aspect-ratio: 1;
 	}
 </style>

--- a/src/components/EpisodePoster.astro
+++ b/src/components/EpisodePoster.astro
@@ -5,6 +5,11 @@
  * text (line-clamp), and container query units already scale type to the
  * card's own width, so there is no line-breaking maths to write or test.
  */
+import ForgeIcon from './ForgeIcon.astro';
+import LibraryIcon from './LibraryIcon.astro';
+import MoonIcon from './MoonIcon.astro';
+import TowerIcon from './TowerIcon.astro';
+
 export interface Props {
 	/** Episode title. Wraps to at most 3 lines, then truncates with an ellipsis. */
 	title: string;
@@ -31,28 +36,14 @@ const a11y: Record<string, string> = decorative
 	{variant === 'poster' && <p class="pixel-eyebrow poster__source">{source}</p>}
 	{variant === 'poster' && <p class="poster__title">{title}</p>}
 	<div class="poster__foot">
-		<svg
-			class="poster__mark"
-			xmlns="http://www.w3.org/2000/svg"
-			viewBox="0 0 48 48"
-			shape-rendering="crispEdges"
-		>
-			<!-- Crenellated shield: castle silhouette reduced to a show mark -->
-			<path
-				d="M8 8H16V12H20V8H28V12H32V8H40V32H36V36H32V40H28V44H20V40H16V36H12V32H8Z"
-				fill="var(--colour-teal-bg)"
-				stroke="var(--colour-gold)"
-				stroke-width="2"></path>
-			<rect x="20" y="12" width="8" height="4" fill="var(--realm-accent)"></rect>
-			<rect
-				x="20"
-				y="20"
-				width="8"
-				height="8"
-				fill="var(--colour-teal-light)"
-				stroke="var(--colour-gold)"
-				stroke-width="2"></rect>
-		</svg>
+		{/* Category glyph, not the show shield: the shield is already in the header,
+		    and the thumbnail should say what the episode is. */}
+		<span class="poster__mark">
+			{realm === 'tower' && <TowerIcon />}
+			{realm === 'library' && <LibraryIcon />}
+			{realm === 'forge' && <ForgeIcon />}
+			{realm === 'moon' && <MoonIcon />}
+		</span>
 	</div>
 </div>
 
@@ -109,6 +100,11 @@ const a11y: Record<string, string> = decorative
 		overflow: hidden;
 	}
 
+	.poster__mark :global(svg) {
+		width: 100%;
+		height: auto;
+	}
+
 	.poster__foot {
 		display: flex;
 		align-items: flex-end;
@@ -123,6 +119,7 @@ const a11y: Record<string, string> = decorative
 	}
 
 	.poster__mark {
+		display: block;
 		width: clamp(var(--space-8), 10cqi, var(--space-16));
 		height: auto;
 		margin-inline-start: auto;

--- a/src/components/EpisodePoster.astro
+++ b/src/components/EpisodePoster.astro
@@ -1,0 +1,131 @@
+---
+/**
+ * Branded 16:9 episode poster — a stand-in for raw Riverside/Zoom screenshots.
+ * Plain HTML + CSS rather than SVG: the browser already wraps and truncates
+ * text (line-clamp), and container query units already scale type to the
+ * card's own width, so there is no line-breaking maths to write or test.
+ */
+export interface Props {
+	/** Episode title. Wraps to at most 3 lines, then truncates with an ellipsis. */
+	title: string;
+	/** Eyebrow label, e.g. "Tower · Talks". Kept short — it is set in the pixel font. */
+	source: string;
+	realm: 'tower' | 'library' | 'forge' | 'moon';
+	date?: Date;
+	/** Poster sits next to the real title, so it is hidden from AT by default. */
+	decorative?: boolean;
+	/** 'poster' bakes the title in, for shares. 'card' omits it, for on-site use. */
+	variant?: 'poster' | 'card';
+}
+
+const { title, source, realm, date, decorative = true, variant = 'poster' } = Astro.props;
+
+const DATE_FORMAT = { year: 'numeric', month: 'long', day: 'numeric' } as const;
+
+const a11y: Record<string, string> = decorative
+	? { 'aria-hidden': 'true' }
+	: { role: 'img', 'aria-label': `${source}: ${title}` };
+---
+
+<div class:list={['poster', `poster--${variant}`]} data-realm={realm} {...a11y}>
+	{variant === 'poster' && <p class="pixel-eyebrow poster__source">{source}</p>}
+	{variant === 'poster' && <p class="poster__title">{title}</p>}
+	<div class="poster__foot">
+		<svg
+			class="poster__mark"
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 48 48"
+			shape-rendering="crispEdges"
+		>
+			<!-- Crenellated shield: castle silhouette reduced to a show mark -->
+			<path
+				d="M8 8H16V12H20V8H28V12H32V8H40V32H36V36H32V40H28V44H20V40H16V36H12V32H8Z"
+				fill="var(--colour-teal-bg)"
+				stroke="var(--colour-gold)"
+				stroke-width="2"></path>
+			<rect x="20" y="12" width="8" height="4" fill="var(--realm-accent)"></rect>
+			<rect
+				x="20"
+				y="20"
+				width="8"
+				height="8"
+				fill="var(--colour-teal-light)"
+				stroke="var(--colour-gold)"
+				stroke-width="2"></rect>
+		</svg>
+	</div>
+</div>
+
+<style>
+	.poster {
+		container-type: inline-size;
+		/* inline-size containment makes the intrinsic width 0, so a flex parent
+		   would shrink this to nothing and aspect-ratio would give it 0 height */
+		width: 100%;
+		display: grid;
+		grid-template-rows: auto 1fr auto;
+		gap: var(--space-2);
+		aspect-ratio: 16 / 9;
+		padding: clamp(var(--space-3), 4cqi, var(--space-8));
+		background-color: var(--colour-teal-dark);
+		/* Faint mortar grid — keeps the flat fill from reading as a blank box */
+		background-image:
+			repeating-linear-gradient(
+				to right,
+				var(--colour-rim-light) 0 2px,
+				transparent 2px var(--space-8)
+			),
+			repeating-linear-gradient(
+				to bottom,
+				var(--colour-rim-light) 0 2px,
+				transparent 2px var(--space-8)
+			);
+		border: 2px solid var(--colour-gold);
+		border-top: 4px solid var(--realm-accent);
+		overflow: hidden;
+	}
+
+	.poster__source {
+		margin: 0;
+		color: var(--realm-accent);
+		/* Pixel font shrinks with the card so it never outgrows a small slot */
+		font-size: min(var(--font-size-xs), 3cqi);
+	}
+
+	.poster__title {
+		margin: 0;
+		align-self: center;
+		font-family: var(--font-display-readable);
+		font-weight: var(--font-weight-bold);
+		letter-spacing: var(--tracking-display-readable);
+		line-height: var(--line-height-snug);
+		font-size: clamp(var(--font-size-base), 6cqi, var(--font-size-5xl));
+		color: var(--colour-gold);
+		/* Native 3-line wrap + ellipsis; no line-breaking maths in the component */
+		display: -webkit-box;
+		-webkit-box-orient: vertical;
+		-webkit-line-clamp: 3;
+		line-clamp: 3;
+		overflow: hidden;
+	}
+
+	.poster__foot {
+		display: flex;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: var(--space-3);
+	}
+
+	.poster__date {
+		font-family: var(--font-body);
+		font-size: min(var(--font-size-sm), 3.5cqi);
+		color: var(--colour-parchment);
+	}
+
+	.poster__mark {
+		width: clamp(var(--space-8), 10cqi, var(--space-16));
+		height: auto;
+		margin-inline-start: auto;
+		image-rendering: pixelated;
+	}
+</style>

--- a/src/components/ListenHub.astro
+++ b/src/components/ListenHub.astro
@@ -75,9 +75,5 @@ const secondary = PODCAST_PLATFORMS.filter((p: PodcastPlatform) => !p.filled);
 
 	.listen-hub__chips--secondary {
 		margin-top: var(--space-4);
-		/* The cartridge paints a 4px drop-shadow below its border box, which ate
-		   4px of the band's bottom padding and made it read tighter than the top.
-		   Collapses through .band-inner and stops at the band's padding edge. */
-		margin-bottom: var(--space-1);
 	}
 </style>

--- a/src/components/ListenHub.astro
+++ b/src/components/ListenHub.astro
@@ -7,6 +7,9 @@ export interface Props {
 }
 
 const { band = false } = Astro.props;
+
+const primary = PODCAST_PLATFORMS.filter((p: PodcastPlatform) => p.filled);
+const secondary = PODCAST_PLATFORMS.filter((p: PodcastPlatform) => !p.filled);
 ---
 
 <section
@@ -15,15 +18,33 @@ const { band = false } = Astro.props;
 	aria-labelledby="listen-heading"
 >
 	<div class:list={[{ 'band-inner': band }]}>
-		<h2 id="listen-heading">Listen to the Podcast</h2>
+		<h2 id="listen-heading" class="section-heading">Listen to the Podcast</h2>
 		<p class="listen-hub__blurb">
-			Two Microsoft MVPs turn cloud security, Azure, and AI into tabletop adventures. Subscribe
-			wherever you listen.
+			Chris Lloyd-Jones and Josh McDonald run cloud security and Microsoft AI as a
+			tabletop campaign, where the monsters are misconfigurations and the loot is an
+			architecture that holds.
 		</p>
 		<div class="listen-hub__chips">
 			{
-				PODCAST_PLATFORMS.map((platform: PodcastPlatform) => (
-					<SubscribeChip href={platform.href} label={platform.label} platform={platform.label} />
+				primary.map((platform: PodcastPlatform) => (
+					<SubscribeChip
+						href={platform.href}
+						label={platform.label}
+						platform={platform.label}
+						filled={true}
+					/>
+				))
+			}
+		</div>
+		<div class="listen-hub__chips listen-hub__chips--secondary">
+			{
+				secondary.map((platform: PodcastPlatform) => (
+					<SubscribeChip
+						href={platform.href}
+						label={platform.label}
+						platform={platform.label}
+						filled={false}
+					/>
 				))
 			}
 		</div>
@@ -46,5 +67,9 @@ const { band = false } = Astro.props;
 		gap: var(--space-3);
 		flex-wrap: wrap;
 		justify-content: center;
+	}
+
+	.listen-hub__chips--secondary {
+		margin-top: var(--space-4);
 	}
 </style>

--- a/src/components/ListenHub.astro
+++ b/src/components/ListenHub.astro
@@ -59,17 +59,25 @@ const secondary = PODCAST_PLATFORMS.filter((p: PodcastPlatform) => !p.filled);
 	.listen-hub__blurb {
 		max-width: var(--max-width-narrow);
 		margin-inline: auto;
-		margin-bottom: var(--space-6);
+		/* 40px down to the first cartridge row — the same step the heading takes
+		   down to this blurb, so the band reads as one ladder. */
+		margin-bottom: var(--space-heading);
 	}
 
+	/* 16px on both axes, so chips that wrap within a row sit the same distance
+	   apart as the two rows do. Matches the button-row gap used site-wide. */
 	.listen-hub__chips {
 		display: flex;
-		gap: var(--space-3);
+		gap: var(--space-4);
 		flex-wrap: wrap;
 		justify-content: center;
 	}
 
 	.listen-hub__chips--secondary {
 		margin-top: var(--space-4);
+		/* The cartridge paints a 4px drop-shadow below its border box, which ate
+		   4px of the band's bottom padding and made it read tighter than the top.
+		   Collapses through .band-inner and stops at the band's padding edge. */
+		margin-bottom: var(--space-1);
 	}
 </style>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -4,7 +4,17 @@ import { buildSearchIndex } from '../utils/search';
 const searchData = await buildSearchIndex();
 ---
 
+<!--
+  Ships expanded and collapses on load, so search still works without JS.
+-->
 <div class="search-container">
+	<button type="button" class="search-toggle" aria-label="Search" title="Search (press /)" aria-expanded="true" aria-controls="search-input" hidden>
+		<svg viewBox="0 0 24 24" width="20" height="20" aria-hidden="true" focusable="false" shape-rendering="crispEdges">
+			<path
+				d="M4 2h8v2H4zM2 4h2v8H2zM12 4h2v8h-2zM4 12h8v2H4zM12 12h2v2h-2zM14 14h2v2h-2zM16 16h2v2h-2zM18 18h2v2h-2z"
+				fill="currentColor"></path>
+		</svg>
+	</button>
 	<div class="search-wrapper">
 		<label for="search-input" class="sr-only">Search content</label>
 		<input
@@ -41,9 +51,42 @@ const searchData = await buildSearchIndex();
 	const searchInput = document.getElementById('search-input') as HTMLInputElement;
 	const searchResultsEl = document.getElementById('search-results') as HTMLElement;
 
-	if (!searchInput || !searchResultsEl) {
+	const searchContainer = document.querySelector('.search-container') as HTMLElement;
+	const searchToggle = document.querySelector('.search-toggle') as HTMLButtonElement;
+
+	if (!searchInput || !searchResultsEl || !searchContainer || !searchToggle) {
 		throw new Error('Search elements not found');
 	}
+
+	// Collapse on load: the markup ships expanded so a no-JS visitor still gets a
+	// working search box.
+	searchToggle.hidden = false;
+	setExpanded(false);
+
+	function setExpanded(expanded: boolean) {
+		searchContainer.classList.toggle('is-expanded', expanded);
+		searchToggle.setAttribute('aria-expanded', String(expanded));
+		if (expanded) {
+			searchInput.focus();
+		} else {
+			searchInput.value = '';
+			hideResults();
+		}
+	}
+
+	searchToggle.addEventListener('click', () => {
+		setExpanded(!searchContainer.classList.contains('is-expanded'));
+	});
+
+	// "/" is the conventional site-search shortcut; never steal it mid-typing.
+	document.addEventListener('keydown', (e: KeyboardEvent) => {
+		if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
+		const active = document.activeElement as HTMLElement | null;
+		if (active?.isContentEditable) return;
+		if (active && ['INPUT', 'TEXTAREA', 'SELECT'].includes(active.tagName)) return;
+		e.preventDefault();
+		setExpanded(true);
+	});
 
 	let selectedIndex = -1;
 	let searchTrackTimeout: ReturnType<typeof setTimeout> | undefined;
@@ -84,14 +127,11 @@ const searchData = await buildSearchIndex();
 				break;
 			case 'Enter':
 				e.preventDefault();
-				if (selectedIndex >= 0 && resultItems[selectedIndex]) {
-					const link = resultItems[selectedIndex].querySelector('a') as HTMLAnchorElement | null;
-					if (link) link.click();
-				}
+					(resultItems[selectedIndex] as HTMLAnchorElement | undefined)?.click();
 				break;
 			case 'Escape':
-				hideResults();
-				searchInput.blur();
+				setExpanded(false);
+				searchToggle.focus();
 				break;
 		}
 	});
@@ -99,7 +139,7 @@ const searchData = await buildSearchIndex();
 	document.addEventListener('click', (e: MouseEvent) => {
 		const target = e.target as HTMLElement;
 		if (!target.closest('.search-container')) {
-			hideResults();
+			setExpanded(false);
 		}
 	});
 
@@ -119,17 +159,16 @@ const searchData = await buildSearchIndex();
 		// Built as DOM nodes, not innerHTML: titles and descriptions include
 		// YouTube feed text, which is not ours to trust.
 		for (const [index, item] of results.entries()) {
-			const wrapper = document.createElement('div');
-			wrapper.className = 'search-result';
-			wrapper.setAttribute('role', 'option');
-			wrapper.setAttribute('aria-selected', String(index === selectedIndex));
-			wrapper.dataset.index = String(index);
-
+			// The anchor IS the option: role="option" must not wrap interactive children.
 			const link = document.createElement('a');
 			link.href = item.url;
+			link.className = 'search-result';
+			link.id = `search-result-${index}`;
+			link.setAttribute('role', 'option');
+			link.setAttribute('aria-selected', 'false');
 
 			for (const [className, text] of [
-				['result-type', `${getTypeIcon(item.type)} ${item.type}`],
+				['result-type', item.type],
 				['result-title', item.title],
 				['result-description', truncate(item.description, 100)],
 			]) {
@@ -139,8 +178,7 @@ const searchData = await buildSearchIndex();
 				link.append(line);
 			}
 
-			wrapper.append(link);
-			searchResultsEl.append(wrapper);
+			searchResultsEl.append(link);
 		}
 
 		showResults();
@@ -152,10 +190,12 @@ const searchData = await buildSearchIndex();
 			if (index === selectedIndex) {
 				item.setAttribute('aria-selected', 'true');
 				item.scrollIntoView({ block: 'nearest' });
+				searchInput.setAttribute('aria-activedescendant', item.id);
 			} else {
 				item.setAttribute('aria-selected', 'false');
 			}
 		});
+		if (selectedIndex < 0) searchInput.removeAttribute('aria-activedescendant');
 	}
 
 	function showResults() {
@@ -169,34 +209,79 @@ const searchData = await buildSearchIndex();
 		selectedIndex = -1;
 	}
 
-	function getTypeIcon(type: string) {
-		switch (type) {
-			case 'blog':
-				return '\u{1F4DA}';
-			case 'talk':
-				return '\u{1F3F0}';
-			case 'project':
-				return '\u2692\uFE0F';
-			default:
-				return '\u{1F4C4}';
-		}
-	}
-
+	// The index is summarised at build time; this is only a hard length guard.
 	function truncate(text: string, length: number) {
 		if (text.length <= length) return text;
-		return text.slice(0, length) + '...';
+		const cut = text.slice(0, length);
+		const lastSpace = cut.lastIndexOf(' ');
+		return `${cut.slice(0, lastSpace > 0 ? lastSpace : cut.length).replace(/[\s,:;-]+$/, '')}\u2026`;
 	}
 </script>
 
 <style>
 	.search-container {
 		position: relative;
-		width: 100%;
-		max-width: 400px;
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+	}
+
+	/* Icon only: no box. The 44px tap target stays, the chrome goes. */
+	.search-toggle {
+		position: relative;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 44px;
+		height: 44px;
+		flex-shrink: 0;
+		padding: 0;
+		background: transparent;
+		border: 0;
+		color: var(--colour-gold);
+		cursor: pointer;
+	}
+
+	/*
+	 * Hover/focus tell: a 2px gold underline block that steps in under the glyph.
+	 * Inset by --space-3 either side so it lines up with the 20px icon.
+	 * The keyboard focus ring itself is the global button:focus-visible outline —
+	 * this bar is on top of it, never instead of it.
+	 */
+	.search-toggle::after {
+		content: '';
+		position: absolute;
+		bottom: var(--space-2);
+		left: var(--space-3);
+		right: var(--space-3);
+		height: 2px;
+		background: var(--colour-gold);
+		transform: scaleX(0);
+		transition: transform 100ms steps(2);
+	}
+
+	.search-toggle:hover::after,
+	.search-toggle:focus-visible::after {
+		transform: scaleX(1);
+	}
+
+	.search-container.is-expanded .search-toggle {
+		display: none;
 	}
 
 	.search-wrapper {
-		position: relative;
+		position: absolute;
+		top: 50%;
+		right: 0;
+		transform: translateY(-50%);
+		width: min(320px, 60vw);
+		/* Opaque: the expanded field sits over the wordmark */
+		background: var(--colour-bg-primary);
+		z-index: var(--z-index-dropdown);
+	}
+
+	.search-container:not(.is-expanded) .search-wrapper {
+		display: none;
 	}
 
 	#search-input {
@@ -235,47 +320,50 @@ const searchData = await buildSearchIndex();
 		box-shadow: 0 4px 12px var(--colour-shadow);
 	}
 
-	.search-result {
-		border-bottom: 1px solid var(--colour-gold);
-	}
-
-	.search-result:last-child {
-		border-bottom: none;
-	}
-
-	.search-result a {
+	/*
+	 * Results are built in JS, so they never get Astro's scope attribute.
+	 * :global keeps the rules alive; the #search-results prefix stops them leaking.
+	 */
+	#search-results :global(.search-result) {
 		display: block;
 		padding: var(--space-3);
 		text-decoration: none;
 		color: var(--colour-parchment);
+		border-bottom: 1px solid var(--colour-gold);
 		transition: background var(--transition-fast);
 	}
 
-	.search-result a:hover,
-	.search-result[aria-selected='true'] a {
+	#search-results :global(.search-result:last-child) {
+		border-bottom: none;
+	}
+
+	#search-results :global(.search-result:hover),
+	#search-results :global(.search-result:focus-visible),
+	#search-results :global(.search-result[aria-selected='true']) {
 		background: var(--colour-gold-alpha-15);
 	}
 
-	.result-type {
+	#search-results :global(.result-type) {
 		font-size: var(--font-size-xs);
 		color: var(--colour-stone-light);
 		text-transform: uppercase;
+		letter-spacing: var(--tracking-display-readable);
 		margin-bottom: var(--space-1);
 	}
 
-	.result-title {
+	#search-results :global(.result-title) {
 		font-weight: var(--font-weight-bold);
 		margin-bottom: var(--space-1);
 		color: var(--colour-gold);
 	}
 
-	.result-description {
+	#search-results :global(.result-description) {
 		font-size: var(--font-size-sm);
 		color: var(--colour-stone-light);
 		line-height: var(--line-height-relaxed);
 	}
 
-	.no-results {
+	#search-results :global(.no-results) {
 		padding: var(--space-4);
 		text-align: center;
 		color: var(--colour-stone-light);
@@ -295,9 +383,21 @@ const searchData = await buildSearchIndex();
 	}
 
 	/* Mobile responsive */
+	/* Mobile: expanded search takes a full-width row beneath the header bar */
 	@media (max-width: 768px) {
-		.search-container {
-			max-width: 100%;
+		.search-container.is-expanded {
+			position: static;
+		}
+
+		.search-container.is-expanded .search-wrapper {
+			position: absolute;
+			top: 100%;
+			left: 0;
+			right: 0;
+			max-width: none;
+			padding: var(--space-2) var(--space-4);
+			background: var(--colour-bg-primary);
+			border-bottom: 2px solid var(--colour-gold);
 		}
 
 		#search-results {
@@ -307,8 +407,9 @@ const searchData = await buildSearchIndex();
 
 	/* Reduced motion */
 	@media (prefers-reduced-motion: reduce) {
+		.search-toggle::after,
 		#search-input,
-		.search-result a {
+		#search-results :global(.search-result) {
 			transition: none;
 		}
 	}

--- a/src/components/SubscribeChip.astro
+++ b/src/components/SubscribeChip.astro
@@ -3,19 +3,77 @@ export interface Props {
 	href: string;
 	label: string;
 	platform: string;
+	filled?: boolean;
 }
 
-const { href, label, platform } = Astro.props;
+const { href, label, platform, filled = true } = Astro.props;
 ---
 
 <a
 	href={href}
-	class="btn-primary btn-sm"
-	style="border-radius: var(--radius-full);"
+	class:list={['cartridge', { 'cartridge--outline': !filled }]}
 	data-social={platform}
 	target="_blank"
 	rel="noopener noreferrer"
 	aria-label={`${label} (opens in new tab)`}
 >
-	{label}
+	<span class="cartridge__face notched">{label}</span>
 </a>
+
+<style>
+	/* The face carries the notch, so its offset shadow cannot be a box-shadow:
+	   clip-path clips outer box-shadows away. A zero-blur drop-shadow on the
+	   wrapper follows the notched silhouette at the same 4px stepped offset. */
+	.cartridge {
+		display: inline-block;
+		filter: drop-shadow(var(--space-1) var(--space-1) 0 var(--realm-shadow));
+		transition: filter 100ms steps(2);
+	}
+
+	.cartridge__face {
+		display: inline-flex;
+		align-items: center;
+		padding: var(--space-2) var(--space-4);
+		background: var(--colour-gold);
+		color: var(--colour-ink);
+		border: 2px solid var(--colour-gold);
+		border-radius: var(--radius-pixel);
+		font-size: var(--font-size-sm);
+		font-weight: var(--font-weight-bold);
+		transition: transform 100ms steps(2), background-color var(--transition-base);
+	}
+
+	/* Opaque, not transparent: the wrapper's drop-shadow follows whatever is
+	   painted, so a see-through face made it trace the letterforms and stamp an
+	   offset ghost of the label across itself. */
+	.cartridge--outline .cartridge__face {
+		background: var(--colour-teal-dark);
+		color: var(--colour-gold);
+	}
+
+	/* Press mechanics match .btn-primary: the face slides into its own shadow */
+	.cartridge:hover .cartridge__face {
+		transform: translate(2px, 2px);
+	}
+
+	.cartridge:hover {
+		filter: drop-shadow(2px 2px 0 var(--realm-shadow));
+	}
+
+	.cartridge:active .cartridge__face {
+		transform: translate(var(--space-1), var(--space-1));
+	}
+
+	.cartridge:active {
+		filter: none;
+	}
+
+	.cartridge--outline:hover .cartridge__face {
+		background: var(--colour-teal-light);
+	}
+
+	/* The filter would draw a gold-dark ghost of the focus ring, so drop it */
+	.cartridge:focus-visible {
+		filter: none;
+	}
+</style>

--- a/src/components/VideoFacade.astro
+++ b/src/components/VideoFacade.astro
@@ -1,0 +1,132 @@
+---
+/**
+ * Click-to-load YouTube facade. Renders a poster and a play button; the real
+ * iframe is only created on click, so no third-party player loads on page view.
+ * Without JS the anchor is a plain link to YouTube.
+ */
+export interface Props {
+	embedUrl: string;
+	videoUrl: string;
+	title: string;
+	thumbnailUrl?: string | null;
+	/** Set on the first facade in the viewport so the poster is not lazy-loaded. */
+	eager?: boolean;
+}
+
+const { embedUrl, videoUrl, title, thumbnailUrl, eager = false } = Astro.props;
+---
+
+<div class="video-frame">
+	<a
+		class="video-facade"
+		href={videoUrl}
+		data-embed={embedUrl}
+		data-title={title}
+		target="_blank"
+		rel="noopener noreferrer"
+		data-action="video"
+		aria-label={`Play video: ${title} (opens YouTube)`}
+	>
+		{/* A poster slot beats the raw YouTube still: multi-cam recordings letterbox
+		    and crop faces. Callers pass a branded poster; the still is the fallback. */}
+		<slot name="poster">
+			{
+				thumbnailUrl && (
+					<img
+						src={thumbnailUrl}
+						alt=""
+						loading={eager ? 'eager' : 'lazy'}
+						width="480"
+						height="270"
+					/>
+				)
+			}
+		</slot>
+		<span class="video-facade__play" aria-hidden="true"></span>
+	</a>
+</div>
+
+<style>
+	.video-frame {
+		position: relative;
+		aspect-ratio: 16 / 9;
+		background: var(--colour-black);
+		overflow: hidden;
+	}
+
+	.video-facade {
+		position: absolute;
+		inset: 0;
+		display: block;
+	}
+
+	/* Inset ring so it isn't clipped by the frame's overflow: hidden */
+	.video-facade:focus-visible {
+		outline: 3px solid var(--colour-gold);
+		outline-offset: calc(-1 * var(--space-1));
+	}
+
+	.video-facade img,
+	.video-facade :global(> *:not(.video-facade__play)) {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		display: block;
+	}
+
+	.video-facade__play {
+		position: absolute;
+		right: var(--space-4);
+		bottom: var(--space-4);
+		width: var(--space-16);
+		height: var(--space-16);
+		background: var(--colour-gold);
+		border: 2px solid var(--colour-ink);
+		border-radius: var(--radius-pixel);
+	}
+
+	/* Pixel play triangle, stacked rectangles - no smooth curves */
+	.video-facade__play::before {
+		content: '';
+		position: absolute;
+		top: 50%;
+		left: 55%;
+		transform: translate(-50%, -50%);
+		border-style: solid;
+		border-width: var(--space-3) 0 var(--space-3) var(--space-4);
+		border-color: transparent transparent transparent var(--colour-ink);
+	}
+
+	.video-frame :global(iframe) {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
+</style>
+
+<script is:inline>
+	// Defer the heavy player until intent.
+	document.querySelectorAll('.video-facade').forEach(function (facade) {
+		facade.addEventListener('click', function (event) {
+			var embed = facade.getAttribute('data-embed');
+			if (!embed) return; // without JS the link just opens YouTube
+			event.preventDefault();
+			var frame = facade.parentNode;
+			var iframe = document.createElement('iframe');
+			iframe.setAttribute('src', embed + '?autoplay=1');
+			iframe.setAttribute('title', facade.getAttribute('data-title') || 'Video');
+			iframe.setAttribute(
+				'allow',
+				'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+			);
+			iframe.setAttribute('allowfullscreen', '');
+			iframe.setAttribute(
+				'sandbox',
+				'allow-scripts allow-same-origin allow-presentation allow-popups'
+			);
+			frame.replaceChild(iframe, facade);
+		});
+	});
+</script>

--- a/src/content/talks/securing-the-realm-purview-mcp-and-agentic-communi.json
+++ b/src/content/talks/securing-the-realm-purview-mcp-and-agentic-communi.json
@@ -3,7 +3,7 @@
   "date": "2025-04-29",
   "event": "YouTube - Securing the Realm",
   "videoUrl": "https://www.youtube.com/watch?v=Y8XAdQiR1D0",
-  "summary": "In this conversation, Josh McDonald and Chris Lloyd-Jones discuss the importance of securing communications in the realm of agentic AI. They explore the CIA triangle of security—confidentiality, in...",
+  "summary": "Josh McDonald and Chris Lloyd-Jones on securing communications between agents: confidentiality, integrity and availability, and what each one costs you when agents talk to each other.",
   "tags": [
     "YouTube",
     "Video"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -194,9 +194,15 @@ const currentPath = Astro.url.pathname;
             loading="lazy"
           />
           <p>Cloud security and Microsoft AI, run as a tabletop campaign.</p>
+          {/* "4.0" was orphaning onto its own line. Non-breaking spaces alone
+              don't fix it — the browser then breaks at the hyphen inside
+              "BY-SA" — so the identifier is held by nowrap instead, which
+              covers both the spaces and the hyphen. Same for the symbol and
+              its year. */}
           <p class="site-footer__licence">
-            © {new Date().getFullYear()} Securing the Realm. Site text is licensed
-            under CC BY-SA 4.0. The code is MIT.
+            <span class="site-footer__nowrap">© {new Date().getFullYear()}</span> Securing the Realm.
+            Site text is licensed under <span class="site-footer__nowrap">CC BY-SA 4.0</span>. The
+            code is MIT.
           </p>
         </div>
 
@@ -347,6 +353,10 @@ const currentPath = Astro.url.pathname;
         font-size: var(--font-size-sm);
         color: var(--colour-stone-light);
         margin-bottom: 0;
+      }
+
+      .site-footer__nowrap {
+        white-space: nowrap;
       }
 
       .site-footer__col ul {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -81,7 +81,17 @@ const currentPath = Astro.url.pathname;
             class="logo-link"
             aria-label="Securing the Realm - Home"
           >
-            <Image src={logoSrc} alt="Securing the Realm logo" class="logo-img" width={48} height={48} loading="eager" />
+            {/* densities: the 1024px source was being emitted at a single 48px, so
+                every 2x display scaled it up and the shield looked soft */}
+            <Image
+              src={logoSrc}
+              alt="Securing the Realm logo"
+              class="logo-img"
+              width={48}
+              height={48}
+              densities={[1, 2, 3]}
+              loading="eager"
+            />
             <span class="logo-text">
               Securing the Realm
             </span>
@@ -100,11 +110,18 @@ const currentPath = Astro.url.pathname;
             <span class="hamburger"></span>
           </button>
 
+          {/* Five items. Listen lives on the hero CTA, the castle scene and the
+              Listen band; Newsletter moved to the footer. */}
           <ul class="nav-menu">
             <li>
               <a href="/talks/" class="nav-link" data-castle-name="Tower"
                 aria-current={currentPath.startsWith('/talks') ? 'page' : undefined}
                 >Talks</a>
+            </li>
+            <li>
+              <a href="/shorts/" class="nav-link" data-castle-name="Moon"
+                aria-current={currentPath.startsWith('/shorts') ? 'page' : undefined}
+                >Shorts</a>
             </li>
             <li>
               <a href="/blog/" class="nav-link" data-castle-name="Library"
@@ -115,23 +132,6 @@ const currentPath = Astro.url.pathname;
               <a href="/forge/" class="nav-link" data-castle-name="Forge"
                 aria-current={currentPath.startsWith('/forge') ? 'page' : undefined}
                 >Code</a>
-            </li>
-            <li>
-              <a href="/shorts/" class="nav-link" data-castle-name="Moon"
-                aria-current={currentPath.startsWith('/shorts') ? 'page' : undefined}
-                >Shorts</a>
-            </li>
-            <li>
-              <a href="/#listen" class="nav-link" data-castle-name="Podcast">Listen</a>
-            </li>
-            <li>
-              <a
-                href="https://str.riverside.com/newsletter"
-                class="nav-link"
-                data-castle-name="Arcane Scrolls"
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="Newsletter (opens in new tab)">Newsletter</a>
             </li>
             <li><a href="/about/" aria-current={currentPath.startsWith('/about') ? 'page' : undefined}>About</a></li>
           </ul>
@@ -181,82 +181,149 @@ const currentPath = Astro.url.pathname;
       <slot />
     </main>
 
-    <footer
-      class="container"
-      style="margin-top: var(--space-16); padding: var(--space-8) 0; border-top: 2px solid var(--colour-gold);"
-    >
-      <div style="text-align: center;">
-        <h2
-          style="font-size: var(--font-size-lg); margin-bottom: var(--space-4);"
-        >
-          Elsewhere
-        </h2>
-        <ul
-          style="display: flex; justify-content: center; gap: var(--space-4) var(--space-8); flex-wrap: wrap; list-style: none; margin: 0;"
-        >
-          <li>
-            <a
-              href="https://www.youtube.com/@SecuringTheRealm"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="YouTube (opens in new tab)"
-              data-social="YouTube">YouTube</a
-            >
-          </li>
-          <li>
-            <a
-              href="https://github.com/SecuringTheRealm"
-              target="_blank"
-              rel="me noopener noreferrer"
-              aria-label="GitHub (opens in new tab)"
-              data-social="GitHub">GitHub</a
-            >
-          </li>
-          <li>
-            <a
-              href="https://www.linkedin.com/company/securingtherealm/"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="LinkedIn (opens in new tab)"
-              data-social="LinkedIn">LinkedIn</a
-            >
-          </li>
-          <li>
-            <a
-              href="https://open.spotify.com/show/1Yo0bHunKuloEXda0Zn3t2"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Spotify (opens in new tab)"
-              data-social="Spotify">Spotify</a
-            >
-          </li>
-          <li>
-            <a
-              href="https://podcasts.apple.com/gb/podcast/securing-the-realm/id1835736136"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Apple Podcasts (opens in new tab)"
-              data-social="Apple Podcasts">Apple Podcasts</a
-            >
-          </li>
-          <li>
-            <a
-              href="https://str.riverside.com/newsletter"
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="Arcane Scrolls newsletter (opens in new tab)"
-              data-social="Newsletter">Newsletter</a
-            >
-          </li>
-        </ul>
-        <p
-          style="margin-top: var(--space-6); font-size: var(--font-size-sm); color: var(--colour-stone-light);"
-        >
-          © {new Date().getFullYear()} Securing the Realm. Content licensed under
-          CC BY-SA 4.0.
-        </p>
+    <footer class="container site-footer">
+      <hr class="pixel-rule" />
+      <div class="site-footer__cols">
+        <div>
+          <Image
+            src={logoSrc}
+            alt="Securing the Realm logo"
+            class="site-footer__shield"
+            width={64}
+            height={64}
+            densities={[1, 2, 3]}
+            loading="lazy"
+          />
+          <p>Cloud security and Microsoft AI, run as a tabletop campaign.</p>
+          <p class="site-footer__licence">
+            © {new Date().getFullYear()} Securing the Realm. Site text is licensed
+            under CC BY-SA 4.0. The code is MIT.
+          </p>
+        </div>
+
+        <nav class="site-footer__col" aria-labelledby="footer-realm">
+          <h2 id="footer-realm" class="pixel-eyebrow">The Realm</h2>
+          <ul>
+            <li><a href="/talks/">Talks</a></li>
+            <li><a href="/blog/">Blog</a></li>
+            <li><a href="/forge/">Code</a></li>
+            <li><a href="/shorts/">Shorts</a></li>
+            <li><a href="/about/">About</a></li>
+          </ul>
+        </nav>
+
+        <nav class="site-footer__col" aria-labelledby="footer-elsewhere">
+          <h2 id="footer-elsewhere" class="pixel-eyebrow">Elsewhere</h2>
+          <ul>
+            <li>
+              <a
+                href="https://www.youtube.com/@SecuringTheRealm"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="YouTube (opens in new tab)"
+                data-social="YouTube">YouTube</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://github.com/SecuringTheRealm"
+                target="_blank"
+                rel="me noopener noreferrer"
+                aria-label="GitHub (opens in new tab)"
+                data-social="GitHub">GitHub</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://www.linkedin.com/company/securingtherealm/"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="LinkedIn (opens in new tab)"
+                data-social="LinkedIn">LinkedIn</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://open.spotify.com/show/1Yo0bHunKuloEXda0Zn3t2"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Spotify (opens in new tab)"
+                data-social="Spotify">Spotify</a
+              >
+            </li>
+            <li>
+              <a
+                href="https://podcasts.apple.com/gb/podcast/securing-the-realm/id1835736136"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Apple Podcasts (opens in new tab)"
+                data-social="Apple Podcasts">Apple Podcasts</a
+              >
+            </li>
+            <li><a href="/blog/rss.xml">Blog RSS</a></li>
+            <li><a href="/shorts/rss.xml">Shorts RSS</a></li>
+            <li><a href="/contact/">Contact</a></li>
+            <li><a href="/privacy/">Privacy</a></li>
+            <li>
+              <a
+                href="https://str.riverside.com/newsletter"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Arcane Scrolls newsletter (opens in new tab)"
+                data-social="Newsletter">Newsletter</a
+              >
+            </li>
+          </ul>
+        </nav>
       </div>
     </footer>
+
+    <style>
+      .site-footer {
+        margin-top: var(--space-16);
+        padding-bottom: var(--space-8);
+      }
+
+      .site-footer .pixel-rule {
+        margin-bottom: var(--space-8);
+      }
+
+      .site-footer__cols {
+        display: grid;
+        grid-template-columns: 2fr 1fr 1fr;
+        align-items: start;
+        gap: var(--space-8);
+      }
+
+      @media (max-width: 767px) {
+        .site-footer__cols {
+          grid-template-columns: 1fr;
+        }
+      }
+
+      .site-footer__shield {
+        display: block;
+        margin-bottom: var(--space-4);
+      }
+
+      .site-footer__licence {
+        font-size: var(--font-size-sm);
+        color: var(--colour-stone-light);
+        margin-bottom: 0;
+      }
+
+      .site-footer__col h2 {
+        margin-bottom: var(--space-4);
+      }
+
+      .site-footer__col ul {
+        display: grid;
+        gap: var(--space-2);
+        justify-items: start;
+        list-style: none;
+        margin: 0;
+      }
+    </style>
 
     <script is:inline>
       document.querySelectorAll('[data-social]').forEach(function (link) {

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -182,9 +182,8 @@ const currentPath = Astro.url.pathname;
     </main>
 
     <footer class="container site-footer">
-      <hr class="pixel-rule" />
       <div class="site-footer__cols">
-        <div>
+        <div class="site-footer__identity">
           <Image
             src={logoSrc}
             alt="Securing the Realm logo"
@@ -212,8 +211,8 @@ const currentPath = Astro.url.pathname;
           </ul>
         </nav>
 
-        <nav class="site-footer__col" aria-labelledby="footer-elsewhere">
-          <h2 id="footer-elsewhere" class="pixel-eyebrow">Elsewhere</h2>
+        <nav class="site-footer__col" aria-labelledby="footer-follow">
+          <h2 id="footer-follow" class="pixel-eyebrow">Follow</h2>
           <ul>
             <li>
               <a
@@ -260,10 +259,14 @@ const currentPath = Astro.url.pathname;
                 data-social="Apple Podcasts">Apple Podcasts</a
               >
             </li>
+          </ul>
+        </nav>
+
+        <nav class="site-footer__col" aria-labelledby="footer-feeds">
+          <h2 id="footer-feeds" class="pixel-eyebrow">Feeds &amp; more</h2>
+          <ul>
             <li><a href="/blog/rss.xml">Blog RSS</a></li>
             <li><a href="/shorts/rss.xml">Shorts RSS</a></li>
-            <li><a href="/contact/">Contact</a></li>
-            <li><a href="/privacy/">Privacy</a></li>
             <li>
               <a
                 href="https://str.riverside.com/newsletter"
@@ -273,29 +276,63 @@ const currentPath = Astro.url.pathname;
                 data-social="Newsletter">Newsletter</a
               >
             </li>
+            <li><a href="/contact/">Contact</a></li>
+            <li><a href="/privacy/">Privacy</a></li>
           </ul>
         </nav>
       </div>
     </footer>
 
     <style>
-      .site-footer {
-        margin-top: var(--space-16);
-        padding-bottom: var(--space-8);
+      /* global.css spreads .nav-wrapper with space-between, which parks the
+         links mid-bar and leaves a dead zone either side. The wordmark takes
+         all the slack instead, so links and search read as one right-hand
+         group. Desktop only — the mobile block owns the wrapped layout. */
+      @media (min-width: 769px) {
+        header .nav-wrapper {
+          justify-content: flex-end;
+          gap: var(--space-6);
+        }
+
+        header .logo-link {
+          margin-right: auto;
+        }
+
+        /* The search glyph is 20px inside a 44px tap target, so its optical
+           edge sat 12px in from the container's 24px inline padding. Pulling
+           the box back by that 12px makes both ends of the header line up,
+           and leaves the links a true 24px off the icon. */
+        header .nav-search {
+          margin-left: 0;
+          margin-right: calc(var(--space-3) * -1);
+        }
       }
 
-      .site-footer .pixel-rule {
-        margin-bottom: var(--space-8);
-      }
-
+      /* The panel's own background, block padding and width cap live in
+         global.css, so this block only lays the columns out.
+         Identity is wide because it carries prose; the three link columns are
+         even. align-items:start puts the shield on the same line as the
+         headings. */
       .site-footer__cols {
         display: grid;
-        grid-template-columns: 2fr 1fr 1fr;
+        grid-template-columns: 2fr 1fr 1fr 1fr;
         align-items: start;
         gap: var(--space-8);
       }
 
-      @media (max-width: 767px) {
+      /* Two up, identity across the top: three link columns at tablet width
+         squeeze "Apple Podcasts" onto two lines. */
+      @media (max-width: 768px) {
+        .site-footer__cols {
+          grid-template-columns: 1fr 1fr;
+        }
+
+        .site-footer__identity {
+          grid-column: 1 / -1;
+        }
+      }
+
+      @media (max-width: 480px) {
         .site-footer__cols {
           grid-template-columns: 1fr;
         }
@@ -310,10 +347,6 @@ const currentPath = Astro.url.pathname;
         font-size: var(--font-size-sm);
         color: var(--colour-stone-light);
         margin-bottom: 0;
-      }
-
-      .site-footer__col h2 {
-        margin-bottom: var(--space-4);
       }
 
       .site-footer__col ul {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -9,8 +9,8 @@ import Base from '../layouts/Base.astro';
       You've Ventured Off The Map
     </p>
     <p style="font-size: var(--font-size-lg); margin-bottom: var(--space-8); max-width: 600px; margin-left: auto; margin-right: auto;">
-      It seems you've wandered into uncharted territory. Fear not, brave adventurer! 
-      Use the navigation above to return to familiar lands.
+      This corner of the map was never drawn, brave adventurer. Take one of the roads below before
+      something notices you standing here.
     </p>
     
     <div style="display: flex; gap: var(--space-4); justify-content: center; flex-wrap: wrap;">

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -48,7 +48,7 @@ import { AUTHORS } from '../utils/authors';
     </section>
 
     <section style="margin-bottom: var(--space-12);">
-      <h2 style="text-align: center; margin-bottom: var(--space-6);">Meet the Hosts</h2>
+      <h2 class="section-heading">Meet the Party</h2>
       <div class="host-grid">
         <AuthorCard author={AUTHORS.chris} />
         <AuthorCard author={AUTHORS.josh} />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -18,31 +18,32 @@ import { AUTHORS } from '../utils/authors';
     <section style="margin-bottom: var(--space-8);">
       <h2>Our Mission</h2>
       <p style="font-size: var(--font-size-lg); line-height: var(--line-height-relaxed);">
-        Through epic storytelling and engaging demos, we transform complex topics like deploying
-        Large-Language Models (LLMs), Small-Language Models (SLMs), and Agentic AI into adventurous
-        quests. Dive into technical architectures that showcase secure and scalable AI solutions, learn
-        how to build robust systems for modern applications, and explore the practical challenges of
-        security, performance, and collaboration—wrapped in the magic of role-playing games.
+        Deploying AI is mostly unglamorous. Large-Language Models (LLMs), Small-Language Models
+        (SLMs) and agentic systems all have to be secured, made to perform, and handed over to people
+        who didn't build them. We run it as a campaign because that is honestly how it goes: a party
+        of specialists, a map with unlit corners, and something at the gate that nobody put in the
+        threat model.
       </p>
     </section>
 
     <section style="margin-bottom: var(--space-8);">
       <h2>Who This Is For</h2>
       <p style="line-height: var(--line-height-relaxed);">
-        Whether you're a seasoned tech adventurer or a curious newcomer, you'll gain insights into
-        Azure's cutting-edge capabilities, responsible AI practices, and open-source projects—all
-        while battling kobolds, training AI elves, and unlocking the secrets of the Crystal Keep.
+        If you build on Azure, worry about what your models do once they are in production, or work
+        in the open, this is for you. You will battle kobolds that are already inside the perimeter,
+        train AI elves that would rather improvise, and lay siege to the Crystal Keep. It still has
+        not given up a single secret.
       </p>
     </section>
 
     <section style="margin-bottom: var(--space-8);">
       <h2>What We Cover</h2>
       <ul style="line-height: var(--line-height-relaxed); font-size: var(--font-size-lg);">
-        <li><strong>Azure Cloud Security</strong>: Best practices for securing your cloud infrastructure</li>
-        <li><strong>AI & Machine Learning</strong>: Deploying and managing LLMs, SLMs, and agentic systems</li>
-        <li><strong>DevSecOps</strong>: Integrating security into your development pipeline</li>
-        <li><strong>Open Source Projects</strong>: Contributing to and leveraging community tools</li>
-        <li><strong>Responsible AI</strong>: Ethical considerations and governance frameworks</li>
+        <li><strong>Azure Cloud Security</strong>: Identity, network boundaries, and where your secrets actually live</li>
+        <li><strong>AI & Machine Learning</strong>: Getting LLMs, SLMs and agentic systems out of the demo and into production</li>
+        <li><strong>DevSecOps</strong>: Security checks that run in the pipeline, before anything ships</li>
+        <li><strong>Open Source Projects</strong>: Using community tools, and what it takes to contribute back</li>
+        <li><strong>Responsible AI</strong>: Governance frameworks, and who answers for it when the model gets it wrong</li>
       </ul>
     </section>
 
@@ -61,8 +62,7 @@ import { AUTHORS } from '../utils/authors';
     >
       <h2>Join the Adventure</h2>
       <p style="margin-bottom: var(--space-6);">
-        Ready to embark on this quest? Explore our content, join the community, and together we'll
-        secure the realm!
+        Start with the podcast. The talks are the side quests.
       </p>
       <div style="display: flex; gap: var(--space-4); justify-content: center; flex-wrap: wrap;">
         <a href="#listen" class="btn-primary">Listen to the Podcast</a>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -13,13 +13,16 @@ const sortedPosts = allBlogPosts.sort(
 	(a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
 		b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
 );
+
+// Card previews show a handful of tags; the post itself carries the full set.
+const TAG_LIMIT = 4;
 ---
 
 <Base title="Library - Blog Posts">
   <div class="container page-shell">
     <PageHeader title="The Library · Blog" eyebrow="The Library" realm="library">
       <LibraryIcon slot="icon" />
-      Welcome to the Library, where we document our adventures in technology, security, and AI.
+      Writeups from the Library: the architecture, the security work, and what broke on the way.
       <a
         slot="actions"
         href="/blog/rss.xml"
@@ -33,7 +36,7 @@ const sortedPosts = allBlogPosts.sort(
     <div style="max-width: var(--max-width-content); margin: 0 auto;" data-realm="library">
       {sortedPosts.length === 0 && (
         <p style="text-align: center; color: var(--colour-stone-light); font-size: var(--font-size-lg);">
-          The Library shelves are empty for now. New scrolls will appear here soon!
+          The shelves are bare. New scrolls will appear here.
         </p>
       )}
       {sortedPosts.map((post: CollectionEntry<'blog'>) => (
@@ -46,12 +49,15 @@ const sortedPosts = allBlogPosts.sort(
           </p>
           <p style="margin-bottom: var(--space-4);">{post.data.description}</p>
           {post.data.tags.length > 0 && (
-            <div style="display: flex; gap: var(--space-2); flex-wrap: wrap;">
-              {post.data.tags.map((tag: string) => (
+            <div style="display: flex; gap: var(--space-2); flex-wrap: wrap; align-items: center;">
+              {post.data.tags.slice(0, TAG_LIMIT).map((tag: string) => (
                 <a href={`/tags/${tag}/`} class="tag-chip">
                   {tag}
                 </a>
               ))}
+              {post.data.tags.length > TAG_LIMIT && (
+                <span class="tag-more">+{post.data.tags.length - TAG_LIMIT} more</span>
+              )}
             </div>
           )}
         </article>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,0 +1,144 @@
+---
+import PageHeader from '../components/PageHeader.astro';
+import Base from '../layouts/Base.astro';
+import type { Author, AuthorLink } from '../utils/authors';
+import { AUTHORS } from '../utils/authors';
+
+const hosts: Author[] = [AUTHORS.chris, AUTHORS.josh];
+---
+
+<Base title="Contact" description="Where to find the show and its hosts. There is no contact form.">
+  <div class="container page-shell" style="max-width: var(--max-width-prose);">
+    <PageHeader title="Contact">
+      There is no contact form here. The site is static files with no server behind it to
+      receive one, so these are the places that reach us.
+    </PageHeader>
+
+    <section class="contact-section">
+      <h2>The show</h2>
+      <ul class="contact-list">
+        <li>
+          <a
+            href="https://github.com/SecuringTheRealm"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub organisation (opens in new tab)">GitHub</a
+          >
+          <span
+            >Everything we build in the open. Anything broken on this site belongs in the issue
+            tracker for the securing.quest repository.</span
+          >
+        </li>
+        <li>
+          <a
+            href="https://www.linkedin.com/company/securingtherealm/"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="LinkedIn page for Securing the Realm (opens in new tab)">LinkedIn</a
+          >
+          <span>The page for the show.</span>
+        </li>
+        <li>
+          <a
+            href="https://www.youtube.com/@SecuringTheRealm"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="YouTube channel (opens in new tab)">YouTube</a
+          >
+          <span>Comments on episodes get read.</span>
+        </li>
+        <li>
+          <a href="/blog/">Blog comments</a>
+          <span>Every post has a comment thread. Signing in uses GitHub.</span>
+        </li>
+      </ul>
+      <p class="contact-note">
+        There is no shared inbox for the show, so GitHub or LinkedIn is the way in.
+      </p>
+    </section>
+
+    <section class="contact-section">
+      <h2>The hosts</h2>
+      {
+        hosts.map((host: Author) => (
+          <div class="contact-host">
+            <h3>{host.name}</h3>
+            <ul class="contact-links">
+              {host.links.map((link: AuthorLink) => (
+                <li>
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`${host.name} on ${link.label} (opens in new tab)`}
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      }
+    </section>
+
+    <section class="contact-section">
+      <h2>Before you write</h2>
+      <p>
+        The <a href="/privacy/">privacy page</a> covers what the site loads and who sees your
+        visit. <a href="/about/">About</a> covers what the show is for.
+      </p>
+    </section>
+  </div>
+</Base>
+
+<style>
+  .contact-section {
+    max-width: var(--max-width-prose);
+    margin-bottom: var(--space-8);
+  }
+
+  .contact-section h2 {
+    margin-bottom: var(--space-4);
+  }
+
+  .contact-section p {
+    line-height: var(--line-height-relaxed);
+  }
+
+  .contact-list {
+    display: grid;
+    gap: var(--space-4);
+    list-style: none;
+    margin: 0 0 var(--space-4);
+  }
+
+  .contact-list li {
+    line-height: var(--line-height-relaxed);
+  }
+
+  .contact-list span {
+    display: block;
+    color: var(--colour-stone-light);
+  }
+
+  .contact-note {
+    color: var(--colour-stone-light);
+  }
+
+  .contact-host {
+    margin-bottom: var(--space-6);
+  }
+
+  .contact-host h3 {
+    margin-bottom: var(--space-2);
+  }
+
+  .contact-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-4);
+    list-style: none;
+    margin: 0;
+  }
+</style>

--- a/src/pages/forge/index.astro
+++ b/src/pages/forge/index.astro
@@ -29,7 +29,7 @@ const otherProjects = allProjects
   <div class="container page-shell">
     <PageHeader title="The Forge · Code" eyebrow="The Forge" realm="forge">
       <ForgeIcon slot="icon" />
-      Explore open-source projects, code repositories, and tools crafted in the forge.
+      Open-source projects, templates and the demos built for the show. All of it public.
       <SubscribeChip
         slot="actions"
         href="https://github.com/SecuringTheRealm"

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -318,7 +318,7 @@ const DATE_LOCALE = 'en-GB';
 
     <section
       class="section-stack"
-      style="max-width: var(--max-width-prose); margin: var(--space-16) auto 0 auto; text-align: center;"
+      style="max-width: var(--max-width-prose); margin-inline: auto; text-align: center;"
     >
       <h2 class="section-heading">The Party</h2>
       <p class="measure" style="font-size: var(--font-size-lg); line-height: var(--line-height-relaxed); text-align: center;">
@@ -446,7 +446,7 @@ const DATE_LOCALE = 'en-GB';
 
   /* Realm cards: the accent is a committed material cue, not a hairline */
   .map-subhead {
-    margin: calc(-1 * var(--space-4)) 0 var(--space-8);
+    margin: 0 0 var(--space-heading);
     text-align: center;
     color: var(--colour-stone-light);
   }
@@ -470,12 +470,6 @@ const DATE_LOCALE = 'en-GB';
     color: var(--colour-parchment);
   }
 
-  @media (max-width: 768px) {
-    .newsletter-band {
-      padding-block: var(--space-12);
-    }
-  }
-
   /* The facade is a flex child; without a width its aspect-ratio resolves to zero */
   /* Compact rows */
   .quest-log {
@@ -486,10 +480,6 @@ const DATE_LOCALE = 'en-GB';
     flex-direction: column;
     /* Wide enough that the per-row accent bars read as five marks, not one spine */
     gap: var(--space-4);
-  }
-
-  .section-heading {
-    margin-bottom: var(--space-8);
   }
 
   .quest-log__more {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,9 +3,21 @@ import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
 import CastleSceneRetro from '../components/CastleSceneRetro.astro';
 import CredibilityStrip from '../components/CredibilityStrip.astro';
+import EpisodePoster from '../components/EpisodePoster.astro';
+import ForgeIcon from '../components/ForgeIcon.astro';
+import LibraryIcon from '../components/LibraryIcon.astro';
 import ListenHub from '../components/ListenHub.astro';
+import MoonIcon from '../components/MoonIcon.astro';
+import TowerIcon from '../components/TowerIcon.astro';
+import VideoFacade from '../components/VideoFacade.astro';
 import Base from '../layouts/Base.astro';
-import { fetchYouTubeShorts, fetchYouTubeTalks } from '../utils/youtube';
+import {
+	fetchYouTubeShorts,
+	fetchYouTubeTalks,
+	getYouTubeEmbedUrl,
+	getYouTubeThumbnailUrl,
+	toSummary,
+} from '../utils/youtube';
 
 // Unified content item for the Quest Log feed
 interface FeedItem {
@@ -16,6 +28,10 @@ interface FeedItem {
 	description: string;
 	realm: 'tower' | 'library' | 'forge' | 'moon';
 	external: boolean;
+	/** Video poster where one exists; blog posts and projects have none. */
+	thumbnailUrl: string | null;
+	/** Set for videos so the lead story can play in place. */
+	embedUrl: string | null;
 }
 
 // Get latest blog posts
@@ -37,6 +53,8 @@ const latestBlogPosts: FeedItem[] = blogPosts
 			description: post.data.description,
 			realm: 'library',
 			external: false,
+			thumbnailUrl: null,
+			embedUrl: null,
 		})
 	);
 
@@ -59,6 +77,8 @@ const allTalks: FeedItem[] = [
 			description: talk.data.summary,
 			realm: 'tower',
 			external: false,
+			thumbnailUrl: getYouTubeThumbnailUrl(talk.data.videoUrl),
+			embedUrl: getYouTubeEmbedUrl(talk.data.videoUrl),
 		})
 	),
 	...youtubeTalks
@@ -72,6 +92,8 @@ const allTalks: FeedItem[] = [
 				description: talk.summary,
 				realm: 'tower',
 				external: false,
+				thumbnailUrl: getYouTubeThumbnailUrl(talk.videoUrl),
+				embedUrl: getYouTubeEmbedUrl(talk.videoUrl),
 			})
 		),
 ];
@@ -98,6 +120,8 @@ const latestProjects: FeedItem[] = projects
 			description: project.data.description,
 			realm: 'forge',
 			external: false,
+			thumbnailUrl: null,
+			embedUrl: null,
 		})
 	);
 
@@ -115,6 +139,8 @@ const latestShorts: FeedItem[] = youtubeShorts
 			description: short.description || 'A short from the Securing the Realm YouTube channel.',
 			realm: 'moon',
 			external: true,
+			thumbnailUrl: short.thumbnailUrl || null,
+			embedUrl: short.embedUrl || null,
 		})
 	);
 
@@ -127,214 +153,185 @@ const latestContent: FeedItem[] = [
 ]
 	.sort((a, b) => b.date.valueOf() - a.date.valueOf())
 	.slice(0, 6);
+
+// Editorial feed: newest item leads, the rest run as compact rows.
+const [heroItem, ...restItems] = latestContent;
+
+const DATE_FORMAT = { year: 'numeric', month: 'long', day: 'numeric' } as const;
+const DATE_LOCALE = 'en-GB';
 ---
 
 <Base title="Securing the Realm - Castle Gate">
   <div class="container page-shell">
-    <section class="section-stack" style="text-align: center;">
-      <h1 style="margin-bottom: var(--space-6);">Welcome to the Castle</h1>
-      <p class="hero-lede measure" style="font-size: var(--font-size-lg);">
-        Azure, Microsoft AI, and cybersecurity — explained as a tabletop adventure. The Securing the
-        Realm podcast, talks, and writeups, from two Microsoft MVPs.
-      </p>
-      <p class="hero-audience measure">
-        For the builders, architects, and security folk who have to deploy and defend AI in the real
-        world.
-      </p>
-      <ul class="format-chips" aria-label="What you'll find here">
-        <li>Talks</li>
-        <li>Blog</li>
-        <li>Code</li>
-        <li>Shorts</li>
-        <li>Podcast</li>
-        <li>Newsletter</li>
-      </ul>
-      <p style="margin-top: var(--space-6);">
-        <a href="/#listen" class="btn-primary">Listen to the podcast</a>
-      </p>
-      <div style="margin-top: var(--space-6);">
-        <CredibilityStrip talkCount={allTalks.length} />
+    {/* Hero is left-aligned throughout: copy, CTA and trust bar share one axis.
+        One measure wrapper, not one per paragraph - 66ch resolves against each
+        element's own font-size, so per-paragraph measures gave ragged left edges. */}
+    <section class="section-stack hero">
+      <p class="pixel-eyebrow hero__eyebrow">Welcome to the Castle</p>
+      <h1 class="hero__title">Azure, AI and cybersecurity,<br /> run as a tabletop adventure</h1>
+      <div class="hero__copy">
+        <p class="hero-lede">
+          The Securing the Realm podcast, talks and writeups, from Chris Lloyd-Jones and Josh
+          McDonald. For the people who have to deploy AI and then defend it.
+        </p>
+        <p class="hero-cta">
+          <a href="/#listen" class="btn-primary">Listen to the podcast</a>
+        </p>
+        <CredibilityStrip itemCount={allTalks.length + youtubeShorts.length} />
       </div>
+
+      {
+        heroItem && (
+          <article class="lead-story content-card" data-realm={heroItem.realm}>
+            <div class="lead-story__media">
+              {heroItem.embedUrl ? (
+                <VideoFacade
+                  embedUrl={heroItem.embedUrl}
+                  videoUrl={heroItem.url}
+                  title={heroItem.title}
+                  thumbnailUrl={heroItem.thumbnailUrl}
+                  eager
+                >
+                  <EpisodePoster
+                    slot="poster"
+                    variant="card"
+                    title={heroItem.title}
+                    source={heroItem.source}
+                    realm={heroItem.realm}
+                  />
+                </VideoFacade>
+              ) : (
+                <div class="lead-story__crest" aria-hidden="true">
+                  {heroItem.realm === 'library' && <LibraryIcon />}
+                  {heroItem.realm === 'tower' && <TowerIcon />}
+                  {heroItem.realm === 'forge' && <ForgeIcon />}
+                  {heroItem.realm === 'moon' && <MoonIcon />}
+                </div>
+              )}
+            </div>
+            <div class="lead-story__body">
+              <p class="quest-eyebrow">
+                <span>{heroItem.source}</span>
+                <time datetime={heroItem.date.toISOString()}>
+                  {heroItem.date.toLocaleDateString(DATE_LOCALE, DATE_FORMAT)}
+                </time>
+              </p>
+              <h3 class="lead-story__title">
+                <a
+                  href={heroItem.url}
+                  target={heroItem.external ? '_blank' : undefined}
+                  rel={heroItem.external ? 'noopener noreferrer' : undefined}
+                >
+                  {heroItem.title}
+                  {heroItem.external && (
+                    <span class="ext-glyph" aria-hidden="true">
+                      ↗
+                    </span>
+                  )}
+                  {heroItem.external && <span class="sr-only"> (opens in new tab)</span>}
+                </a>
+              </h3>
+            </div>
+          </article>
+        )
+      }
     </section>
 
-    <section class="section-stack">
-      <!-- Interactive Castle Scene -->
-      <div style="max-width: var(--max-width-wide); margin: 0 auto var(--space-12) auto;">
+    <section class="section-stack" aria-labelledby="map-heading">
+      <h2 id="map-heading" class="section-heading">Map of the Realm</h2>
+      <p class="map-subhead">Every part of the realm, one keep. Pick a door.</p>
+      <div style="max-width: var(--max-width-wide); margin-inline: auto;">
         <CastleSceneRetro />
-      </div>
-
-      <!-- Text-based Navigation Fallback -->
-      <h2 style="text-align: center; margin-bottom: var(--space-8);">Explore the Realm</h2>
-      <div class="realm-grid">
-        <a
-          href="/talks/"
-          class="realm-card content-card glow-on-hover"
-          data-realm="tower"
-          style="text-align: center; display: block;"
-        >
-          <h3 style="margin-bottom: var(--space-4);">Tower · Talks</h3>
-          <p style="margin: 0; color: var(--colour-parchment);">
-            Watch talks and presentations on Azure, AI, and cybersecurity
-          </p>
-        </a>
-
-        <a
-          href="/blog/"
-          class="realm-card content-card glow-on-hover"
-          data-realm="library"
-          style="text-align: center; display: block;"
-        >
-          <h3 style="margin-bottom: var(--space-4);">Library · Blog</h3>
-          <p style="margin: 0; color: var(--colour-parchment);">
-            Read articles and insights on technology and security
-          </p>
-        </a>
-
-        <a
-          href="/forge/"
-          class="realm-card content-card glow-on-hover"
-          data-realm="forge"
-          style="text-align: center; display: block;"
-        >
-          <h3 style="margin-bottom: var(--space-4);">Forge · Code</h3>
-          <p style="margin: 0; color: var(--colour-parchment);">
-            Explore code projects and open-source contributions
-          </p>
-        </a>
-
-        <a
-          href="/shorts/"
-          class="realm-card content-card glow-on-hover"
-          data-realm="moon"
-          style="text-align: center; display: block;"
-        >
-          <h3 style="margin-bottom: var(--space-4);">Moon · Shorts</h3>
-          <p style="margin: 0; color: var(--colour-parchment);">
-            Quick glimpses - bite-sized adventures in security and AI
-          </p>
-        </a>
-
-        <a
-          href="https://str.riverside.com/newsletter"
-          class="realm-card content-card glow-on-hover"
-          data-realm="scrolls"
-          style="text-align: center; display: block;"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Arcane Scrolls newsletter (opens in new tab)"
-        >
-          <h3 style="margin-bottom: var(--space-4);">Scrolls · Newsletter</h3>
-          <p style="margin: 0; color: var(--colour-parchment);">
-            Arcane Scrolls - cybersecurity, Azure and AI in your inbox
-          </p>
-        </a>
       </div>
     </section>
 
     <!-- Latest Content Feed -->
     <section class="section-stack" style="max-width: var(--max-width-content); margin: 0 auto;">
-      <h2 style="text-align: center; margin-bottom: var(--space-8);">Quest Log</h2>
-      <ol class="quest-log">
+      <h2 class="section-heading">Quest Log</h2>
+      <ul class="quest-log">
         {
-          latestContent.map((item: FeedItem, index: number) => (
+          restItems.map((item: FeedItem) => (
             <li>
               <a
                 href={item.url}
-                class="feed-item content-card"
+                class="quest-row"
                 data-realm={item.realm}
                 target={item.external ? '_blank' : undefined}
                 rel={item.external ? 'noopener noreferrer' : undefined}
-                style="display: block; padding: var(--space-4); text-decoration: none;"
               >
-                <div style="display: flex; align-items: flex-start; gap: var(--space-3);">
-                  <span class="quest-log__num" aria-hidden="true">
-                    {index + 1}
+                <span class="quest-row__thumb" aria-hidden="true">
+                  <span class="quest-row__crest">
+                    {item.realm === 'library' && <LibraryIcon />}
+                    {item.realm === 'tower' && <TowerIcon />}
+                    {item.realm === 'forge' && <ForgeIcon />}
+                    {item.realm === 'moon' && <MoonIcon />}
                   </span>
-                  <div style="flex: 1; min-width: 0;">
-                    <div style="display: flex; align-items: baseline; gap: var(--space-2); margin-bottom: var(--space-2); flex-wrap: wrap;">
-                      <h3 style="margin: 0; font-size: var(--font-size-lg);">
-                        {item.title}
-                        {item.external && (
-                          <span class="ext-glyph" aria-hidden="true">
-                            ↗
-                          </span>
-                        )}
-                        {item.external && <span class="sr-only"> (opens in new tab)</span>}
-                      </h3>
-                      <span style="font-size: var(--font-size-xs); color: var(--colour-stone-light); white-space: nowrap;">
-                        {item.source}
-                      </span>
-                    </div>
-                    <p style="margin: 0; color: var(--colour-parchment); font-size: var(--font-size-sm); line-height: var(--line-height-relaxed);">
-                      {item.description.length > 150
-                        ? `${item.description.substring(0, 147)}...`
-                        : item.description}
-                    </p>
-                    <p style="margin-top: var(--space-2); margin-bottom: 0; font-size: var(--font-size-xs); color: var(--colour-stone-light);">
-                      {item.date.toLocaleDateString('en-US', {
-                        year: 'numeric',
-                        month: 'long',
-                        day: 'numeric',
-                      })}
-                    </p>
-                  </div>
-                </div>
+                </span>
+                <span class="quest-row__body">
+                <p class="quest-eyebrow">
+                  <span>{item.source}</span>
+                  <time datetime={item.date.toISOString()}>
+                    {item.date.toLocaleDateString(DATE_LOCALE, DATE_FORMAT)}
+                  </time>
+                </p>
+                <h3 class="quest-row__title">
+                  {item.title}
+                  {item.external && (
+                    <span class="ext-glyph" aria-hidden="true">
+                      ↗
+                    </span>
+                  )}
+                  {item.external && <span class="sr-only"> (opens in new tab)</span>}
+                </h3>
+                <p class="quest-row__summary">{toSummary(item.description, 150)}</p>
+                </span>
               </a>
             </li>
           ))
         }
-      </ol>
+      </ul>
+      <p class="quest-log__more">
+        <a href="/talks/">All talks and episodes →</a>
+      </p>
     </section>
 
+
     <ListenHub band={true} />
+
+    {/* Signup is a hosted Riverside page, so this links out. Swapping the button for
+        an inline field is a small diff once there is an endpoint to POST to. */}
+    <section class="section-stack newsletter-band" aria-labelledby="scrolls-heading">
+      <h2 id="scrolls-heading" class="section-heading">Arcane Scrolls</h2>
+      <p class="newsletter-band__blurb">
+        The newsletter. Episodes and writeups, in your inbox. We send one when there is one.
+      </p>
+      <a
+        href="https://str.riverside.com/newsletter"
+        class="btn-primary notched"
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Subscribe to Arcane Scrolls (opens in new tab)">Subscribe</a
+      >
+    </section>
 
     <section
       class="section-stack"
       style="max-width: var(--max-width-prose); margin: var(--space-16) auto 0 auto; text-align: center;"
     >
-      <h2 style="margin-bottom: var(--space-6);">Our Quest</h2>
+      <h2 class="section-heading">The Party</h2>
       <p class="measure" style="font-size: var(--font-size-lg); line-height: var(--line-height-relaxed);">
-        Through epic storytelling and engaging demos, we transform complex topics like deploying
-        Large-Language Models (LLMs), Small-Language Models (SLMs), and Agentic AI into adventurous
-        quests. Whether you're a seasoned tech adventurer or a curious newcomer, you'll gain insights
-        into Azure's cutting-edge capabilities, responsible AI practices, and open-source projects—all
-        while battling kobolds, training AI elves, and unlocking the secrets of the Crystal Keep.
+        We run large language models, small language models and agentic systems on Azure as a
+        campaign: architecture and live demos on one side of the screen, kobolds at the gate and AI
+        elves in training on the other. The Crystal Keep still refuses to give up its secrets.
       </p>
-      <a
-        href="https://www.youtube.com/@SecuringTheRealm"
-        class="btn-primary"
-        target="_blank"
-        rel="noopener noreferrer"
-        data-social="YouTube"
-        aria-label="Subscribe on YouTube (opens in new tab)"
-        style="margin-top: var(--space-6);"
-      >
-        Subscribe on YouTube
+      <a href="/about/" class="btn-outline notched" style="margin-top: var(--space-6);">
+        Meet the party →
       </a>
     </section>
   </div>
 </Base>
 
 <style>
-  .format-chips {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-2);
-    list-style: none;
-    margin: var(--space-6) 0 0;
-    padding: 0;
-  }
-
-  .format-chips li {
-    font-family: var(--font-display);
-    font-size: var(--font-size-xs);
-    color: var(--colour-gold);
-    border: 2px solid var(--colour-gold);
-    border-radius: var(--radius-sm);
-    padding: var(--space-2) var(--space-3);
-  }
-
   .quest-log {
     list-style: none;
     margin: 0;
@@ -344,28 +341,236 @@ const latestContent: FeedItem[] = [
     gap: var(--space-4);
   }
 
-  .quest-log__num {
-    flex-shrink: 0;
-    min-width: var(--space-8);
-    font-family: var(--font-display);
-    font-size: var(--font-size-lg);
-    color: var(--colour-gold);
-  }
-
   .ext-glyph {
     margin-left: var(--space-1);
     color: var(--colour-gold);
   }
 
-  .realm-card:hover,
-  .feed-item:hover {
+  .hero {
+    display: grid;
+    grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
+    column-gap: var(--space-12);
+    align-items: start;
+  }
+
+  .hero__eyebrow,
+  .hero__title {
+    grid-column: 1 / -1;
+  }
+
+  .hero__title {
+    margin-bottom: var(--space-8);
+    text-wrap: balance;
+  }
+
+  @media (max-width: 900px) {
+    .hero {
+      grid-template-columns: 1fr;
+      gap: var(--space-8);
+    }
+
+    /* Stacked, the row gap already separates the title from the copy */
+    .hero__title {
+      margin-bottom: 0;
+    }
+  }
+
+  .lead-story {
+    display: block;
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .lead-story__media {
+    display: block;
+    border-bottom: 2px solid var(--realm-accent);
+  }
+
+  .lead-story__crest {
+    display: grid;
+    place-items: center;
+    aspect-ratio: 16 / 9;
+    background: var(--colour-teal-dark);
+  }
+
+  .lead-story__body {
+    padding: var(--space-4);
+  }
+
+  .content-card .lead-story__title {
+    margin: 0 0 var(--space-2);
+    font-family: var(--font-display-readable);
+    font-weight: var(--font-weight-bold);
+    font-variant-caps: normal;
+    font-size: var(--font-size-lg);
+    line-height: var(--line-height-snug);
+    letter-spacing: 0;
+    color: var(--colour-gold);
+  }
+
+  .lead-story__title a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .lead-story__title a:hover,
+  .lead-story__title a:focus-visible {
+    text-decoration: underline;
+  }
+
+  .lead-story__summary {
+    margin: 0;
+    color: var(--colour-stone-light);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-relaxed);
+  }
+
+  .hero-lede {
+    font-size: var(--font-size-lg);
+  }
+
+  .hero-cta {
+    margin: var(--space-6) 0 var(--space-4);
+  }
+
+  /* Realm cards: the accent is a committed material cue, not a hairline */
+  .map-subhead {
+    margin: calc(-1 * var(--space-4)) 0 var(--space-8);
+    text-align: center;
+    color: var(--colour-stone-light);
+  }
+
+  .newsletter-band {
+    text-align: center;
+    padding-block: var(--space-16);
+  }
+
+  .newsletter-band__blurb {
+    max-width: var(--max-width-narrow);
+    margin: 0 auto var(--space-6);
+    color: var(--colour-parchment);
+  }
+
+  @media (max-width: 768px) {
+    .newsletter-band {
+      padding-block: var(--space-12);
+    }
+  }
+
+  /* The facade is a flex child; without a width its aspect-ratio resolves to zero */
+  /* Compact rows */
+  .quest-log {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+  }
+
+  .section-heading {
+    margin-bottom: var(--space-8);
+  }
+
+  .quest-log__more {
+    margin: var(--space-6) 0 0;
+  }
+
+  .quest-row {
+    display: grid;
+    grid-template-columns: var(--space-20) minmax(0, 1fr);
+    gap: var(--space-4);
+    align-items: start;
+    padding: var(--space-3) var(--space-4);
+    border-left: 3px solid var(--realm-accent);
+    text-decoration: none;
+    color: inherit;
+    transition: background var(--transition-fast);
+  }
+
+  .quest-row__thumb {
+    display: block;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    background: var(--colour-teal-dark);
+  }
+
+  .quest-row__thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  .quest-row__crest {
+    display: grid;
+    place-items: center;
+    width: 100%;
+    height: 100%;
+  }
+
+  .quest-row__crest :global(svg) {
+    width: var(--space-8);
+    height: var(--space-8);
+  }
+
+  .quest-row:hover,
+  .quest-row:focus-visible {
+    background: var(--colour-teal-dark);
+  }
+
+  .quest-row__title {
+    margin: 0 0 var(--space-1);
+    font-family: var(--font-display-readable);
+    font-weight: var(--font-weight-bold);
+    font-size: var(--font-size-lg);
+    line-height: var(--line-height-snug);
+    letter-spacing: 0;
+    color: var(--colour-gold);
+  }
+
+  .quest-row__summary {
+    margin: 0;
+    color: var(--colour-stone-light);
+    font-size: var(--font-size-sm);
+    line-height: var(--line-height-relaxed);
+  }
+
+  /* Shared eyebrow: source on the left, date on the right */
+  .quest-eyebrow {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: var(--space-3);
+    margin: 0 0 var(--space-2);
+    font-size: var(--font-size-xs);
+    letter-spacing: var(--tracking-display-readable);
+    text-transform: uppercase;
+    color: var(--realm-accent);
+  }
+
+  .quest-eyebrow time {
+    color: var(--colour-stone-light);
+    white-space: nowrap;
+  }
+
+  @media (max-width: 600px) {
+    .quest-row {
+      grid-template-columns: 1fr;
+    }
+
+    .quest-row__thumb {
+      max-width: var(--space-24);
+    }
+  }
+
+  .lead-story:hover {
     transform: translate(2px, 2px);
     box-shadow: var(--card-chrome-pressed);
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .realm-card:hover,
-    .feed-item:hover {
+    .lead-story:hover {
       transform: none;
     }
   }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -334,15 +334,6 @@ const DATE_LOCALE = 'en-GB';
 </Base>
 
 <style>
-  .quest-log {
-    list-style: none;
-    margin: 0;
-    padding: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--space-4);
-  }
-
   .ext-glyph {
     margin-left: var(--space-1);
     color: var(--colour-gold);
@@ -355,11 +346,13 @@ const DATE_LOCALE = 'en-GB';
     align-items: start;
     /* Starfield: the castle band follows immediately, so the hero's empty
        bottom-left reads as the sky above the castle rather than as absence.
-       Kept at 3% so it is texture, never content. No animation. */
+       Same colour as the castle's stars, so the two bands share one sky; the
+       tiles are sparse (~20 dots) to keep the total star weight near the
+       castle's eight, which is what stops it competing with the H1. Static. */
     background-image:
       radial-gradient(var(--colour-star) 1px, transparent 1px),
       radial-gradient(var(--colour-star) 2px, transparent 2px);
-    background-size: var(--space-24) 140px, 200px 220px;
+    background-size: 200px 240px, 360px 320px;
     background-position: 0 0, 72px 88px;
     padding-bottom: var(--space-section);
   }
@@ -446,7 +439,7 @@ const DATE_LOCALE = 'en-GB';
 
   /* Realm cards: the accent is a committed material cue, not a hairline */
   .map-subhead {
-    margin: 0 0 var(--space-heading);
+    margin: 0 0 var(--space-subhead);
     text-align: center;
     color: var(--colour-stone-light);
   }
@@ -457,15 +450,15 @@ const DATE_LOCALE = 'en-GB';
 
   /* A notched panel gives the section edges; without them it floated */
   .newsletter-band__panel {
-    max-width: var(--max-width-content);
+    max-width: var(--measure);
     margin-inline: auto;
-    padding: var(--space-12) var(--space-6);
+    padding: var(--space-12);
     background: var(--colour-teal-dark);
     border: 2px solid var(--colour-gold);
   }
 
+  /* The 720px panel is already the measure, so the blurb needs no width of its own */
   .newsletter-band__blurb {
-    max-width: var(--max-width-narrow);
     margin: 0 auto var(--space-6);
     color: var(--colour-parchment);
   }
@@ -483,9 +476,11 @@ const DATE_LOCALE = 'en-GB';
   }
 
   .quest-log__more {
-    /* Indented to the row titles' x-position, not the container edge */
-    margin: var(--space-6) 0 0;
-    padding-left: calc(var(--space-20) + var(--space-4) + var(--space-4));
+    /* Indented to the row titles' x-position, not the container edge. The inset is
+       the row's own structure — accent bar, row padding, thumb column, grid gap —
+       read from the same tokens the row uses, so it tracks any change to them. */
+    margin: var(--space-heading) 0 0;
+    padding-left: calc(var(--space-1) + var(--space-4) + var(--space-20) + var(--space-4));
   }
 
   .quest-row {
@@ -494,7 +489,7 @@ const DATE_LOCALE = 'en-GB';
     gap: var(--space-4);
     align-items: start;
     padding: var(--space-3) var(--space-4);
-    border-left: 4px solid var(--realm-accent);
+    border-left: var(--space-1) solid var(--realm-accent);
     text-decoration: none;
     color: inherit;
     transition: background var(--transition-fast);
@@ -573,6 +568,11 @@ const DATE_LOCALE = 'en-GB';
 
     .quest-row__thumb {
       max-width: var(--space-24);
+    }
+
+    /* Single column, so the title starts right after the bar and row padding */
+    .quest-log__more {
+      padding-left: calc(var(--space-1) + var(--space-4));
     }
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -301,6 +301,7 @@ const DATE_LOCALE = 'en-GB';
     {/* Signup is a hosted Riverside page, so this links out. Swapping the button for
         an inline field is a small diff once there is an endpoint to POST to. */}
     <section class="section-stack newsletter-band" aria-labelledby="scrolls-heading">
+      <div class="newsletter-band__panel notched">
       <h2 id="scrolls-heading" class="section-heading">Arcane Scrolls</h2>
       <p class="newsletter-band__blurb">
         The newsletter. Episodes and writeups, in your inbox. We send one when there is one.
@@ -312,6 +313,7 @@ const DATE_LOCALE = 'en-GB';
         rel="noopener noreferrer"
         aria-label="Subscribe to Arcane Scrolls (opens in new tab)">Subscribe</a
       >
+      </div>
     </section>
 
     <section
@@ -319,7 +321,7 @@ const DATE_LOCALE = 'en-GB';
       style="max-width: var(--max-width-prose); margin: var(--space-16) auto 0 auto; text-align: center;"
     >
       <h2 class="section-heading">The Party</h2>
-      <p class="measure" style="font-size: var(--font-size-lg); line-height: var(--line-height-relaxed);">
+      <p class="measure" style="font-size: var(--font-size-lg); line-height: var(--line-height-relaxed); text-align: center;">
         We run large language models, small language models and agentic systems on Azure as a
         campaign: architecture and live demos on one side of the screen, kobolds at the gate and AI
         elves in training on the other. The Crystal Keep still refuses to give up its secrets.
@@ -351,6 +353,15 @@ const DATE_LOCALE = 'en-GB';
     grid-template-columns: minmax(0, 6fr) minmax(0, 5fr);
     column-gap: var(--space-12);
     align-items: start;
+    /* Starfield: the castle band follows immediately, so the hero's empty
+       bottom-left reads as the sky above the castle rather than as absence.
+       Kept at 3% so it is texture, never content. No animation. */
+    background-image:
+      radial-gradient(var(--colour-star) 1px, transparent 1px),
+      radial-gradient(var(--colour-star) 2px, transparent 2px);
+    background-size: var(--space-24) 140px, 200px 220px;
+    background-position: 0 0, 72px 88px;
+    padding-bottom: var(--space-section);
   }
 
   .hero__eyebrow,
@@ -359,7 +370,7 @@ const DATE_LOCALE = 'en-GB';
   }
 
   .hero__title {
-    margin-bottom: var(--space-8);
+    margin-bottom: var(--space-heading);
     text-wrap: balance;
   }
 
@@ -442,7 +453,15 @@ const DATE_LOCALE = 'en-GB';
 
   .newsletter-band {
     text-align: center;
-    padding-block: var(--space-16);
+  }
+
+  /* A notched panel gives the section edges; without them it floated */
+  .newsletter-band__panel {
+    max-width: var(--max-width-content);
+    margin-inline: auto;
+    padding: var(--space-12) var(--space-6);
+    background: var(--colour-teal-dark);
+    border: 2px solid var(--colour-gold);
   }
 
   .newsletter-band__blurb {
@@ -465,7 +484,8 @@ const DATE_LOCALE = 'en-GB';
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: var(--space-2);
+    /* Wide enough that the per-row accent bars read as five marks, not one spine */
+    gap: var(--space-4);
   }
 
   .section-heading {
@@ -473,7 +493,9 @@ const DATE_LOCALE = 'en-GB';
   }
 
   .quest-log__more {
+    /* Indented to the row titles' x-position, not the container edge */
     margin: var(--space-6) 0 0;
+    padding-left: calc(var(--space-20) + var(--space-4) + var(--space-4));
   }
 
   .quest-row {
@@ -482,7 +504,7 @@ const DATE_LOCALE = 'en-GB';
     gap: var(--space-4);
     align-items: start;
     padding: var(--space-3) var(--space-4);
-    border-left: 3px solid var(--realm-accent);
+    border-left: 4px solid var(--realm-accent);
     text-decoration: none;
     color: inherit;
     transition: background var(--transition-fast);

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -1,0 +1,142 @@
+---
+import PageHeader from '../components/PageHeader.astro';
+import Base from '../layouts/Base.astro';
+---
+
+<Base
+  title="Privacy"
+  description="What this site loads, what it counts, and which other companies see your visit."
+>
+  <div class="container page-shell" style="max-width: var(--max-width-prose);">
+    <PageHeader title="Privacy">
+      What this site loads, and who else sees your visit. There are no accounts here and no
+      forms to fill in. The site sets no cookies of its own.
+    </PageHeader>
+
+    <section class="privacy-section">
+      <h2>Hosting</h2>
+      <p>
+        The site is a folder of static files served by GitHub Pages. Every request for a page
+        goes to GitHub's servers, so GitHub sees your IP address and browser user agent, the
+        same as any web server would. What they do with that is covered by the
+        <a
+          href="https://docs.github.com/en/site-policy/privacy-policies/github-privacy-statement"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub privacy statement (opens in new tab)">GitHub privacy statement</a
+        >.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Analytics</h2>
+      <p>
+        Visits are counted by Plausible. The script loads from plausible.io and is the
+        outbound-links and file-downloads build, so it records page views, clicks on links that
+        leave the site, and file downloads. Clicking a social, podcast or subscribe link sends
+        one extra event carrying the platform name.
+      </p>
+      <p>
+        Plausible sets no cookies and, by their own account, does not identify individual
+        visitors or follow them across sites. We can tell you what this site sends. What
+        Plausible stores is covered by their
+        <a
+          href="https://plausible.io/data-policy"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Plausible data policy (opens in new tab)">data policy</a
+        >.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Video</h2>
+      <p>
+        Talks and shorts show a still image with a play button over it. The still is served by
+        YouTube's image host, i.ytimg.com, so a request reaches Google when the page loads.
+      </p>
+      <p>
+        The player is different. It only appears after you click, and it loads from
+        youtube-nocookie.com. Until you click there is no YouTube player on the page.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Comments</h2>
+      <p>
+        Blog posts carry comments, run by Giscus on top of GitHub Discussions. The Giscus script
+        loads from giscus.app when the post opens, before you interact with it. Leaving a
+        comment needs a GitHub account, and the comment is stored publicly in the
+        SecuringTheRealm/securing.quest repository.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Newsletter</h2>
+      <p>
+        The newsletter sign-up is a page hosted by Riverside at str.riverside.com, and the link
+        takes you off this site. The form lives on their page, so this site never handles your
+        address.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Search</h2>
+      <p>
+        The search box runs in your browser. Its index is already inside the page you
+        downloaded, so what you type stays on your machine.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Fonts</h2>
+      <p>
+        The heading font, Press Start 2P, is served from this site. Body text is Georgia, which
+        your device already has. Nothing is requested from Google Fonts.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Webmentions</h2>
+      <p>
+        Blog posts can show webmentions, which are replies and likes from other websites. That
+        data is collected when the site is built rather than when you visit. If a mention has an
+        author photo, the image loads from wherever that author hosts it. Nothing is showing at
+        the moment, because none have come in yet.
+      </p>
+      <p>
+        The page source also advertises a webmention endpoint at webmention.io. That is an
+        address for other sites to send notifications to, and your browser never contacts it.
+      </p>
+    </section>
+
+    <section class="privacy-section">
+      <h2>Questions</h2>
+      <p>
+        Ways to reach us are on the <a href="/contact/">contact page</a>.
+      </p>
+      <p class="privacy-updated">Checked against the site's code on 28 July 2026.</p>
+    </section>
+  </div>
+</Base>
+
+<style>
+  .privacy-section {
+    max-width: var(--max-width-prose);
+    margin-bottom: var(--space-8);
+  }
+
+  .privacy-section h2 {
+    margin-bottom: var(--space-4);
+  }
+
+  .privacy-section p {
+    line-height: var(--line-height-relaxed);
+    margin-bottom: var(--space-4);
+  }
+
+  .privacy-updated {
+    font-size: var(--font-size-sm);
+    color: var(--colour-stone-light);
+  }
+</style>

--- a/src/pages/shorts/index.astro
+++ b/src/pages/shorts/index.astro
@@ -44,7 +44,7 @@ const sortedShorts = mergedShorts.sort((a, b) => b.pubDate.valueOf() - a.pubDate
   <div class="container page-shell">
     <PageHeader title="The Moon · Shorts" eyebrow="The Moon" realm="moon">
       <MoonIcon slot="icon" />
-      Quick glimpses into the realm - bite-sized adventures in security, AI, and beyond.
+      A minute or two from the Moon. One idea, no preamble.
       <SubscribeChip
         slot="actions"
         href="https://www.youtube.com/@SecuringTheRealm"
@@ -56,16 +56,18 @@ const sortedShorts = mergedShorts.sort((a, b) => b.pubDate.valueOf() - a.pubDate
     <div class="shorts-grid" data-realm="moon">
       {sortedShorts.length === 0 && (
         <p style="text-align: center; color: var(--colour-stone-light); font-size: var(--font-size-lg); grid-column: 1 / -1;">
-          No shorts yet. Quick glimpses into the realm will appear here soon!
+          Nothing from the Moon yet. Look up again shortly.
         </p>
       )}
-      {sortedShorts.map((short) => (
+      {sortedShorts.map((short, index) => (
         <article class="short-card">
           <a href={short.videoUrl} target="_blank" rel="noopener noreferrer" class="short-thumbnail-link" aria-label={`Watch ${short.title} on YouTube`}>
             <img
               src={short.thumbnailUrl}
               alt={short.title}
-              loading="lazy"
+              width="480"
+              height="360"
+              loading={index < 3 ? 'eager' : 'lazy'}
               class="short-thumbnail"
             />
             <span class="play-icon" aria-hidden="true">&#9654;</span>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -3,7 +3,7 @@ import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
 import type { GetStaticPaths } from 'astro';
 import Base from '../../layouts/Base.astro';
-import { fetchYouTubeShorts, fetchYouTubeTalks } from '../../utils/youtube';
+import { fetchYouTubeShorts, fetchYouTubeTalks, toSummary } from '../../utils/youtube';
 
 interface TaggedContent {
 	title: string;
@@ -150,9 +150,7 @@ const { tag, items } = Astro.props as Props;
                 </span>
               </div>
               <p style="margin: 0; color: var(--colour-parchment); font-size: var(--font-size-sm); line-height: var(--line-height-relaxed);">
-                {item.description.length > 150
-                  ? `${item.description.substring(0, 147)}...`
-                  : item.description}
+                {toSummary(item.description, 150)}
               </p>
               <p style="margin-top: var(--space-2); margin-bottom: 0; font-size: var(--font-size-xs); color: var(--colour-stone-light);">
                 {item.date.toLocaleDateString('en-US', {

--- a/src/pages/talks/index.astro
+++ b/src/pages/talks/index.astro
@@ -73,7 +73,7 @@ const allTalks = [...unifiedManualTalks, ...unifiedYouTubeTalks].sort(
   <div class="container page-shell">
     <PageHeader title="The Tower · Talks" eyebrow="The Tower" realm="tower">
       <TowerIcon slot="icon" />
-      Watch talks, presentations, and video content from conferences and events.
+      Full sessions and recorded talks, from conference stages and from the studio.
       <SubscribeChip
         slot="actions"
         href="https://www.youtube.com/@SecuringTheRealm"
@@ -88,7 +88,7 @@ const allTalks = [...unifiedManualTalks, ...unifiedYouTubeTalks].sort(
           No talks yet. Check back soon for upcoming presentations!
         </p>
       )}
-      {allTalks.map((talk: UnifiedTalk) => (
+      {allTalks.map((talk: UnifiedTalk, index: number) => (
         <article id={talk.id} class="content-card" style="margin-bottom: var(--space-12);">
           <h2 style="margin-bottom: var(--space-3);">{talk.title}</h2>
           <p style="font-size: var(--font-size-sm); color: var(--colour-stone-light); margin-bottom: var(--space-2);">
@@ -109,7 +109,7 @@ const allTalks = [...unifiedManualTalks, ...unifiedYouTubeTalks].sort(
                 aria-label={`Play video: ${talk.title} (opens YouTube)`}
               >
                 {talk.thumbnailUrl && (
-                  <img src={talk.thumbnailUrl} alt="" loading="lazy" width="480" height="270" />
+                  <img src={talk.thumbnailUrl} alt="" loading={index === 0 ? 'eager' : 'lazy'} width="480" height="270" />
                 )}
                 <span class="video-facade__play" aria-hidden="true" />
               </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -106,6 +106,13 @@ h1, h2, h3, h4, h5, h6 {
   background: var(--pixel-dash);
 }
 
+/* Inside a notched panel the box is already the frame, so the flanking rules
+   would be a second border 48px in from the first. */
+.notched > .section-heading::before,
+.notched > .section-heading::after {
+  display: none;
+}
+
 /* Fluid so long headings shrink instead of wrapping brutally on mobile */
 h1 {
   font-size: clamp(var(--font-size-2xl), 5vw, var(--font-size-5xl));

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,7 +94,7 @@ h1, h2, h3, h4, h5, h6 {
   text-align: center;
   text-wrap: balance;
   color: var(--colour-gold);
-  margin-bottom: var(--space-8);
+  margin-bottom: var(--space-heading);
 }
 
 .section-heading::before,
@@ -313,11 +313,13 @@ img {
 }
 
 /* Utility Classes */
+/* padding-inline, not the `padding` shorthand: the shorthand also zeroed
+   padding-block, so .page-shell only won its own block padding by source order. */
 .container {
   width: 100%;
-  max-width: var(--max-width-wide);
+  max-width: var(--container);
   margin: 0 auto;
-  padding: 0 var(--space-4);
+  padding-inline: var(--space-6);
 }
 
 .measure {
@@ -326,12 +328,19 @@ img {
   text-align: left;
 }
 
+/* Sections own every gap; nothing owns a rhythm margin. One seam is exactly one
+   --space-section, never a bottom margin plus a top padding plus a wrapper. */
 .page-shell {
-  padding-block: var(--space-12);
+  padding-block: var(--space-section);
 }
 
 .section-stack {
-  margin-bottom: var(--space-12);
+  padding-block-end: var(--space-section);
+}
+
+/* The shell already pads the gap before the footer; two would double it. */
+.section-stack:last-child {
+  padding-block-end: 0;
 }
 
 /* Ornaments — the 8-bit chrome. Replaces gold hairlines and middot separators. */
@@ -567,7 +576,7 @@ img {
 /* Card styles — carved-stone surface echoing the castle's depth bands */
 .stone-card,
 .content-card {
-  padding: var(--space-6);
+  padding: var(--space-inner);
   background: var(--colour-teal-dark);
   border: 2px solid var(--colour-gold);
   border-radius: var(--radius-pixel);
@@ -637,14 +646,38 @@ button:hover {
 .section--band {
   width: 100vw;
   margin-inline: calc(50% - 50vw);
-  padding-block: var(--space-16);
+  padding-block: var(--space-section);
   background: var(--colour-teal-dark);
+}
+
+/* A band's two colour edges need the same air. The section above supplies the gap
+   over the top edge with its padding-block-end; nothing supplies the one under the
+   bottom edge, because a band may not carry a margin. This does. */
+.section--band + .section-stack {
+  padding-block-start: var(--space-section);
 }
 
 .section--band > .band-inner {
   max-width: var(--max-width-content);
   margin-inline: auto;
-  padding-inline: var(--space-4);
+  padding-inline: var(--space-6);
+}
+
+/* Closing panel. The colour change is the separator, so the full-width dashed rule
+   goes: dashes belong to heading flanks only. The width cap and gutter move off the
+   footer (so the panel bleeds) onto its columns, which read the same --container as
+   the shell — so footer text lines up with page text at every breakpoint. */
+.site-footer {
+  max-width: none;
+  padding-block: var(--space-section);
+  padding-inline: 0;
+  background: var(--colour-teal-dark);
+}
+
+.site-footer__cols {
+  max-width: var(--container);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
 }
 
 /* Per-realm house colours — one metallic family, all ≥4.5:1 on both teals */
@@ -724,12 +757,6 @@ button:hover {
   /* Add padding to main content so it doesn't hide under sticky header */
   main {
     padding-top: var(--space-2);
-  }
-
-  /* Reduce hero/page container top padding on mobile (overrides inline styles) */
-  main > .container {
-    padding-top: var(--space-8) !important;
-    padding-bottom: var(--space-8) !important;
   }
 
   .nav-wrapper {
@@ -822,16 +849,6 @@ button:hover {
     flex-basis: var(--space-8);
   }
 
-  /* Improve mobile card grid */
-  .container {
-    padding: 0 var(--space-3);
-  }
-
-  /* Better mobile spacing for sections */
-  section {
-    margin-bottom: var(--space-8) !important;
-  }
-
   /* Improve mobile buttons — enforce 44px minimum touch target */
   .btn-primary,
   .btn-outline {
@@ -843,19 +860,11 @@ button:hover {
   }
 }
 
-/* Tablet breakpoint */
-@media (max-width: 1024px) and (min-width: 769px) {
-  .container {
-    max-width: var(--max-width-content);
-  }
-}
+/* Tablet container width now steps via --container in tokens.css, so the
+   full-bleed footer is not re-capped here. */
 
 /* Small mobile */
 @media (max-width: 480px) {
-  .container {
-    padding: 0 var(--space-2);
-  }
-
   /* Stack cards vertically on very small screens */
   .realm-grid {
     grid-template-columns: 1fr;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -334,13 +334,17 @@ img {
   padding-block: var(--space-section);
 }
 
-.section-stack {
-  padding-block-end: var(--space-section);
+/* Where the page is built from sections, they own every seam themselves, so the
+   shell must not add a second helping at the top and bottom of the page. */
+.page-shell:has(> .section-stack) {
+  padding-block: 0;
 }
 
-/* The shell already pads the gap before the footer; two would double it. */
-.section-stack:last-child {
-  padding-block-end: 0;
+/* Symmetric, so every background edge sits exactly halfway through its seam.
+   Asymmetric padding put the whole gap on one side of the edge, which is what
+   made the band seams read as uneven. */
+.section-stack {
+  padding-block: var(--space-section);
 }
 
 /* Ornaments — the 8-bit chrome. Replaces gold hairlines and middot separators. */
@@ -653,10 +657,6 @@ button:hover {
 /* A band's two colour edges need the same air. The section above supplies the gap
    over the top edge with its padding-block-end; nothing supplies the one under the
    bottom edge, because a band may not carry a margin. This does. */
-.section--band + .section-stack {
-  padding-block-start: var(--space-section);
-}
-
 .section--band > .band-inner {
   max-width: var(--max-width-content);
   margin-inline: auto;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,41 +42,78 @@ body {
   overflow-x: hidden;
 }
 
-/* Typography */
+/* Typography — headings are bold Georgia. Press Start 2P is reserved for the
+   wordmark and small pixel labels (.pixel-eyebrow): at display size its width
+   and tracking make a sentence unscannable. */
 h1, h2, h3, h4, h5, h6 {
-  font-family: var(--font-display);
-  line-height: var(--line-height-display);
-  letter-spacing: var(--tracking-display);
+  font-family: var(--font-display-readable);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-snug);
+  letter-spacing: normal;
   text-wrap: balance;
   color: var(--colour-gold);
   margin-bottom: var(--space-4);
 }
 
-/* Readable display tier — sentence-shaped headings and card/feed/listing
-   titles use bold Georgia (no third font file) so long strings stay legible */
-.prose h2,
-.prose h3,
-.prose h4,
+/* Small-caps is the card/feed voice only — prose headings stay plain so the
+   page carries two voices (pixel label, serif heading), not three */
 .content-card h2,
 .content-card h3,
 .feed-item h3,
 .short-title {
-  font-family: var(--font-display-readable);
-  font-weight: var(--font-weight-bold);
   font-variant-caps: small-caps;
   letter-spacing: var(--tracking-display-readable);
-  line-height: var(--line-height-snug);
-  color: var(--colour-gold);
-  text-wrap: balance;
 }
 
+/* Pixel eyebrow: the one place Press Start 2P belongs outside the wordmark */
+.pixel-eyebrow {
+  font-family: var(--font-display);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-display);
+  letter-spacing: var(--tracking-display-readable);
+  text-transform: uppercase;
+  color: var(--colour-gold);
+}
+
+/* Section heading: pixel is the voice of the interface. Beats the base h1..h6
+   rule on class specificity (0,1,0 vs 0,0,1), so no !important is needed.
+   Flex centres the text between two pixel rules of a FIXED length: the call
+   sites sit in containers of three different widths, and rules that grew to
+   fill made every heading a different component. */
+.section-heading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-4);
+  font-family: var(--font-display);
+  /* Flat 24px, not a viewport clamp — a clamp made the same heading a different
+     size per breakpoint. html drops to 14px under 768px, so this is 21px there. */
+  font-size: var(--font-size-2xl);
+  line-height: var(--line-height-display);
+  letter-spacing: 0.1em;
+  text-align: center;
+  text-wrap: balance;
+  color: var(--colour-gold);
+  margin-bottom: var(--space-8);
+}
+
+.section-heading::before,
+.section-heading::after {
+  content: '';
+  /* 0 0 basis, so the rule is 96px wide in every container. Never grows. */
+  flex: 0 0 var(--space-24);
+  height: 2px;
+  background: var(--pixel-dash);
+}
+
+/* Fluid so long headings shrink instead of wrapping brutally on mobile */
 h1 {
-  font-size: var(--font-size-3xl);
+  font-size: clamp(var(--font-size-2xl), 5vw, var(--font-size-5xl));
   margin-bottom: var(--space-6);
 }
 
 h2 {
-  font-size: var(--font-size-2xl);
+  font-size: clamp(var(--font-size-xl), 3.5vw, var(--font-size-3xl));
 }
 
 h3 {
@@ -290,11 +327,70 @@ img {
 }
 
 .page-shell {
-  padding-block: var(--space-16);
+  padding-block: var(--space-12);
 }
 
 .section-stack {
-  margin-bottom: var(--space-16);
+  margin-bottom: var(--space-12);
+}
+
+/* Ornaments — the 8-bit chrome. Replaces gold hairlines and middot separators. */
+
+/* Standalone pixel-dash divider. On an <hr>, border:0 kills the default rule. */
+.pixel-rule {
+  height: 2px;
+  border: 0;
+  background: var(--pixel-dash);
+}
+
+/* Container class: draws a 5x5 pixel diamond between inline children.
+   Put it on the list/paragraph, not the item. */
+.pixel-diamond > :not(:last-child)::after {
+  content: '';
+  display: inline-block;
+  width: var(--pixel-glyph-size);
+  height: var(--pixel-glyph-size);
+  margin-inline-start: var(--space-3);
+  vertical-align: middle;
+  background: var(--colour-gold);
+  mask: var(--pixel-diamond-mask) center / contain no-repeat;
+  -webkit-mask: var(--pixel-diamond-mask) center / contain no-repeat;
+}
+
+/* 4px square notches clipped from each corner, so panels read as 8-bit windows.
+   No clip-path support degrades to a plain square. Note: clip-path also clips
+   outer box-shadows, so keep it off surfaces carrying --shadow-stepped. */
+.notched {
+  clip-path: polygon(
+    var(--notch) 0,
+    calc(100% - var(--notch)) 0,
+    calc(100% - var(--notch)) var(--notch),
+    100% var(--notch),
+    100% calc(100% - var(--notch)),
+    calc(100% - var(--notch)) calc(100% - var(--notch)),
+    calc(100% - var(--notch)) 100%,
+    var(--notch) 100%,
+    var(--notch) calc(100% - var(--notch)),
+    0 calc(100% - var(--notch)),
+    0 var(--notch),
+    var(--notch) var(--notch)
+  );
+}
+
+/* Clipping would swallow the focus outline, so drop the notch while focused */
+.notched:focus-visible,
+.notched:has(:focus-visible) {
+  clip-path: none;
+}
+
+/* The site's one date style. Serif small-caps, not pixel: at <=768px the root
+   drops to 14px, which would put Press Start 2P off its own pixel grid. */
+.meta-date {
+  font-family: var(--font-body);
+  font-variant-caps: small-caps;
+  font-size: var(--font-size-sm);
+  letter-spacing: var(--tracking-display-readable);
+  color: var(--colour-stone-light);
 }
 
 /* Animations */
@@ -328,7 +424,6 @@ img {
   display: flex;
   align-items: center;
   gap: var(--space-3);
-  z-index: var(--z-index-sticky);
 }
 
 .logo-img {
@@ -338,17 +433,21 @@ img {
 }
 
 .logo-text {
+  white-space: nowrap;
   font-family: var(--font-display);
   font-size: var(--font-size-lg);
   line-height: 1.4;
 }
 
+/* Search collapses to a 44px icon, so the header no longer reserves a wide column.
+   order:1 puts it after the nav links (every other nav-wrapper child is order:0),
+   far right of the bar. No auto margin: .nav-wrapper's space-between does the
+   spreading, so the links sit between the wordmark and the search icon. */
 .nav-search {
-  flex: 1;
   display: flex;
-  justify-content: center;
-  max-width: 500px;
-  margin: 0 var(--space-4);
+  justify-content: flex-end;
+  order: 1;
+  margin-left: var(--space-6);
   z-index: var(--z-index-dropdown);
 }
 
@@ -430,7 +529,6 @@ img {
   box-shadow: var(--shadow-stepped);
   font-weight: var(--font-weight-bold);
   text-decoration: none;
-  transition: all var(--transition-base);
   cursor: pointer;
 }
 
@@ -451,7 +549,6 @@ img {
   box-shadow: var(--shadow-stepped);
   font-weight: var(--font-weight-bold);
   text-decoration: none;
-  transition: all var(--transition-base);
   cursor: pointer;
 }
 
@@ -477,16 +574,42 @@ img {
   box-shadow: var(--card-chrome);
 }
 
-/* Navigation card grid */
-.realm-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: var(--space-6);
+/* clip-path clips outer box-shadows, so a notched card keeps the inset chrome
+   and drops the stepped offset rather than showing a half-eaten one. */
+.stone-card.notched,
+.content-card.notched {
+  box-shadow: var(--card-chrome-inset);
 }
 
+/* Navigation card grid */
+/* Explicit column counts, not auto-fit: five realms must not leave an orphan card */
+.realm-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+@media (max-width: 999px) {
+  .realm-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: var(--space-6);
+  }
+}
+
+/* The 8-bit tell is stepped easing. Movement snaps in two frames; colour still
+   eases, because a stepped colour change reads as a rendering fault. */
 button,
-.realm-card {
-  transition: all var(--transition-base);
+.realm-card,
+.stone-card,
+.content-card,
+.btn-primary,
+.btn-outline {
+  transition:
+    transform 100ms steps(2),
+    box-shadow 100ms steps(2),
+    background-color var(--transition-base),
+    border-color var(--transition-base),
+    color var(--transition-base);
 }
 
 button:hover {
@@ -509,14 +632,13 @@ button:hover {
   padding-bottom: var(--space-1);
 }
 
-/* Full-bleed banded section for homepage rhythm/depth */
+/* Full-bleed banded section for homepage rhythm/depth. The background is the
+   only separator — edge rules on top of it delimited the band twice. */
 .section--band {
   width: 100vw;
   margin-inline: calc(50% - 50vw);
   padding-block: var(--space-16);
   background: var(--colour-teal-dark);
-  border-top: 2px solid var(--colour-gold);
-  border-bottom: 2px solid var(--colour-gold);
 }
 
 .section--band > .band-inner {
@@ -525,40 +647,50 @@ button:hover {
   padding-inline: var(--space-4);
 }
 
-/* Per-realm house colours — accent applied to borders only to preserve AA */
-[data-realm="forge"] { --realm-accent: var(--colour-forge-orange); }
-[data-realm="moon"] { --realm-accent: var(--colour-parchment-light); }
-[data-realm="tower"] { --realm-accent: var(--colour-stone-light); }
-[data-realm="library"] { --realm-accent: var(--colour-gold); }
-[data-realm="scrolls"] { --realm-accent: var(--colour-parchment); }
+/* Per-realm house colours — one metallic family, all ≥4.5:1 on both teals */
+[data-realm="tower"] { --realm-accent: var(--colour-brass); }
+[data-realm="forge"] { --realm-accent: var(--colour-copper); }
+[data-realm="moon"] { --realm-accent: var(--colour-silver-blue); }
+[data-realm="library"] { --realm-accent: var(--colour-parchment-dark); }
+
+/* Tint the offset shadow to the house colour so border and shadow read as one
+   system. Same 85% darkening that gold-dark is to gold. */
+[data-realm] {
+  --realm-shadow: color-mix(in srgb, var(--realm-accent) 85%, var(--colour-black));
+}
 
 .realm-card[data-realm] {
   border-top: 4px solid var(--realm-accent);
 }
 
 /* Tag/source chip: gold fill + ink text (AA), house colour on the border */
+/* Outline, not filled: tags are metadata and must not outrank the title or the CTA */
 .tag-chip {
   font-size: var(--font-size-sm);
   padding: var(--space-1) var(--space-3);
-  background: var(--colour-gold);
-  color: var(--colour-ink);
-  border: 2px solid var(--realm-accent);
+  background: transparent;
+  color: var(--colour-stone-light);
+  border: 2px solid var(--colour-stone-dark);
   border-radius: var(--radius-full);
   text-decoration: none;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.tag-chip:hover,
+.tag-chip:focus-visible {
+  color: var(--realm-accent);
+  border-color: var(--realm-accent);
+}
+
+.tag-more {
+  font-size: var(--font-size-sm);
+  color: var(--colour-stone-light);
 }
 
 /* Responsive utilities */
 @media (max-width: 768px) {
   html {
     font-size: 14px;
-  }
-
-  h1 {
-    font-size: var(--font-size-2xl);
-  }
-
-  h2 {
-    font-size: var(--font-size-xl);
   }
 
   /* Sticky header on mobile */
@@ -616,15 +748,14 @@ button:hover {
   }
 
   .logo-text {
-    display: none;
+    font-size: var(--font-size-xs);
   }
 
   .nav-search {
     order: 2;
-    position: relative;
-    flex: 1 1 auto;
-    margin: 0;
-    max-width: none;
+    position: static;
+    flex: 0 0 auto;
+    margin: 0 0 0 auto;
     z-index: var(--z-index-dropdown);
   }
 
@@ -685,6 +816,12 @@ button:hover {
     display: none;
   }
 
+  /* 96px each side would push a pixel heading off-centre at 390px */
+  .section-heading::before,
+  .section-heading::after {
+    flex-basis: var(--space-8);
+  }
+
   /* Improve mobile card grid */
   .container {
     padding: 0 var(--space-3);
@@ -706,25 +843,10 @@ button:hover {
   }
 }
 
-/* Wide desktop: show all 4 realm cards in a single row */
-@media (min-width: 1200px) {
-  .realm-grid {
-    grid-template-columns: repeat(4, 1fr);
-  }
-}
-
 /* Tablet breakpoint */
 @media (max-width: 1024px) and (min-width: 769px) {
   .container {
     max-width: var(--max-width-content);
-  }
-
-  h1 {
-    font-size: var(--font-size-3xl);
-  }
-
-  .nav-search {
-    min-width: 120px;
   }
 }
 
@@ -732,14 +854,6 @@ button:hover {
 @media (max-width: 480px) {
   .container {
     padding: 0 var(--space-2);
-  }
-
-  h1 {
-    font-size: var(--font-size-xl);
-  }
-
-  h2 {
-    font-size: var(--font-size-lg);
   }
 
   /* Stack cards vertically on very small screens */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -11,7 +11,9 @@
   --colour-gold: #d5a425;
   --colour-gold-light: #e8be4a;
   --colour-gold-dark: #b8901f;
-  --colour-stone: #8a877f;
+  /* Lightened from #8a877f: it carries 12px webmention timestamps on
+     --colour-teal-dark, where the old value was 4.35:1 (AA needs 4.5) */
+  --colour-stone: #949189;
   --colour-stone-light: #c4c1b8;
   --colour-stone-dark: #6f6d67;
   --colour-parchment: #f3e9d2;
@@ -20,6 +22,13 @@
   --colour-ink: #1a1a1a;
   --colour-white: #ffffff;
   --colour-black: #000000;
+
+  /* Realm accents — one metallic family so the four cards read as a set.
+     Bone reuses --colour-parchment-dark. Distinct from the castle's forge
+     fire below, which stays fully saturated. */
+  --colour-brass: #c9a45a;
+  --colour-copper: #d19470;
+  --colour-silver-blue: #a9bcc9;
 
   /* Castle/Environment Colors */
   --colour-sky-dark: #0a1820;
@@ -43,6 +52,9 @@
 
   /* Per-realm accent (overridden per [data-realm]) */
   --realm-accent: var(--colour-gold);
+  /* Offset shadow colour. Realm cards darken their own accent (see global.css);
+     everything else keeps the literal gold-dark. */
+  --realm-shadow: var(--colour-gold-dark);
 
   /* Spacing Scale */
   --space-1: 4px;
@@ -78,10 +90,22 @@
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
 
   /* Stepped pixel shadows (no blur) + carved-stone card chrome */
-  --shadow-stepped: 4px 4px 0 var(--colour-gold-dark);
-  --shadow-stepped-hover: 2px 2px 0 var(--colour-gold-dark);
-  --card-chrome: inset 0 2px 0 var(--colour-rim-light), inset -2px 0 0 var(--colour-rim-light), inset 0 -2px 0 var(--colour-shadow-band), inset 2px 0 0 var(--colour-shadow-band), var(--shadow-stepped);
-  --card-chrome-pressed: inset 0 2px 0 var(--colour-rim-light), inset -2px 0 0 var(--colour-rim-light), inset 0 -2px 0 var(--colour-shadow-band), inset 2px 0 0 var(--colour-shadow-band), var(--shadow-stepped-hover);
+  --shadow-stepped: 4px 4px 0 var(--realm-shadow);
+  --shadow-stepped-hover: 2px 2px 0 var(--realm-shadow);
+  --card-chrome-inset: inset 0 2px 0 var(--colour-rim-light), inset -2px 0 0 var(--colour-rim-light), inset 0 -2px 0 var(--colour-shadow-band), inset 2px 0 0 var(--colour-shadow-band);
+  --card-chrome: var(--card-chrome-inset), var(--shadow-stepped);
+  --card-chrome-pressed: var(--card-chrome-inset), var(--shadow-stepped-hover);
+
+  /* 8-bit ornament kit */
+  /* 4px-on/4px-off gold dash: section-heading flanks and standalone rules */
+  --pixel-dash: repeating-linear-gradient(90deg, var(--colour-gold) 0 var(--space-1), transparent var(--space-1) var(--space-2));
+  /* 5x5 stepped diamond, used as a mask so the fill stays a colour token */
+  --pixel-diamond-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 5 5'%3E%3Cpath d='M2 0h1v1h1v1h1v1h-1v1h-1v1h-1v-1h-1v-1h-1v-1h1v-1h1z'/%3E%3C/svg%3E");
+  /* 10px = exactly 2x the 5px diamond grid. No spacing token divides by 5, and a
+     fractional scale would blur the steps, so this one is deliberately literal. */
+  --pixel-glyph-size: 10px;
+  /* Corner notch depth for .notched; matches the 4px pixel unit */
+  --notch: var(--space-1);
 
   /* Typography Scale */
   --font-size-xs: 0.75rem;    /* 12px */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -49,6 +49,8 @@
   --colour-shadow: color-mix(in srgb, var(--colour-black) 30%, transparent);
   --colour-rim-light: color-mix(in srgb, var(--colour-white) 12%, transparent);
   --colour-shadow-band: color-mix(in srgb, var(--colour-black) 15%, transparent);
+  /* Hero starfield: texture only, must never read as content */
+  --colour-star: color-mix(in srgb, var(--colour-parchment) 3%, transparent);
 
   /* Per-realm accent (overridden per [data-realm]) */
   --realm-accent: var(--colour-gold);
@@ -56,24 +58,40 @@
      everything else keeps the literal gold-dark. */
   --realm-shadow: var(--colour-gold-dark);
 
-  /* Spacing Scale */
+  /* Spacing Scale — 8px grid, name is px/4 */
   --space-1: 4px;
   --space-2: 8px;
   --space-3: 12px;
   --space-4: 16px;
   --space-6: 24px;
   --space-8: 32px;
+  --space-10: 40px;
   --space-12: 48px;
+  --space-14: 56px;
   --space-16: 64px;
   --space-20: 80px;
   --space-24: 96px;
 
+  /* Semantic rhythm. Three values carry the whole vertical page; any gap that
+     is none of these is an ad-hoc value and should be replaced by one. */
+  --space-section: var(--space-24); /* seam between bands (see breakpoint below) */
+  --space-heading: var(--space-10); /* heading to its subhead or content */
+  --space-inner: var(--space-6);    /* card and panel padding */
+
   /* Layout Widths */
   --max-width-prose: 800px;
   --max-width-content: 900px;
-  --max-width-narrow: 700px;
   --max-width-wide: 1200px;
-  --measure: 66ch;
+  /* The one page width. Bands, rows and the footer columns all read this, so a
+     full-bleed panel can align its content to the shell without duplicating the
+     breakpoint. Stepped down at tablet (see breakpoint below). */
+  --container: var(--max-width-wide);
+  /* Fixed px, not ch: ch resolves against each element's own font-size, so the
+     same token gave the Listen subhead and the Party paragraph different widths. */
+  --measure: 720px;
+  /* Deprecated alias — prose measure is --measure. Delete once .listen-hub__blurb,
+     .newsletter-band__blurb and .page-header__intro reference --measure directly. */
+  --max-width-narrow: var(--measure);
 
   /* Border Radius */
   --radius-sm: 4px;
@@ -138,6 +156,22 @@
   --z-index-dropdown: 1000;
   --z-index-sticky: 1020;
   --z-index-modal: 1050;
+}
+
+@media (max-width: 1024px) and (min-width: 769px) {
+  :root {
+    --container: var(--max-width-content);
+  }
+}
+
+/* One breakpoint, not a clamp(): a clamp gives the seam a different value at every
+   viewport width, which is the exact fault this token exists to remove — the seam
+   has to be provably identical everywhere. 768px is where the root font-size
+   already steps, so the page changes gear once. */
+@media (max-width: 768px) {
+  :root {
+    --space-section: var(--space-14);
+  }
 }
 
 /* Reduced Motion Support */

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -49,8 +49,11 @@
   --colour-shadow: color-mix(in srgb, var(--colour-black) 30%, transparent);
   --colour-rim-light: color-mix(in srgb, var(--colour-white) 12%, transparent);
   --colour-shadow-band: color-mix(in srgb, var(--colour-black) 15%, transparent);
-  /* Hero starfield: texture only, must never read as content */
-  --colour-star: color-mix(in srgb, var(--colour-parchment) 3%, transparent);
+  /* Hero starfield. The castle band's stars are flat --colour-parchment (its
+     twinkle floor is 0.6), so the hero matches that colour at the floor value:
+     the same sky, one band up. Density carries the restraint instead of alpha —
+     see .hero's background-size. */
+  --colour-star: color-mix(in srgb, var(--colour-parchment) 60%, transparent);
 
   /* Per-realm accent (overridden per [data-realm]) */
   --realm-accent: var(--colour-gold);
@@ -72,10 +75,11 @@
   --space-20: 80px;
   --space-24: 96px;
 
-  /* Semantic rhythm. Three values carry the whole vertical page; any gap that
+  /* Semantic rhythm. These values carry the whole vertical page; any gap that
      is none of these is an ad-hoc value and should be replaced by one. */
   --space-section: var(--space-24); /* seam between bands (see breakpoint below) */
   --space-heading: var(--space-10); /* heading to its subhead or content */
+  --space-subhead: var(--space-12); /* subhead line to the section's major content */
   --space-inner: var(--space-6);    /* card and panel padding */
 
   /* Layout Widths */

--- a/src/utils/authors.ts
+++ b/src/utils/authors.ts
@@ -16,7 +16,7 @@ export const AUTHORS: Record<'chris' | 'josh', Author> = {
 		id: 'chris',
 		name: 'Chris Lloyd-Jones',
 		role: 'VP, AI Consulting Transformation · Kyndryl',
-		bio: 'Chris Lloyd-Jones is VP for AI Consulting Transformation at Kyndryl, where he created and leads the Forward Deployed Engineering capability that pairs engineers directly with clients. A six-time Microsoft MVP in AI, he is also a doctoral researcher in green software engineering and a contributor to the ISO/IEC 21031:2024 Software Carbon Intensity standard. His work spans agentic AI, open source, and sustainable, secure-by-design systems, and in 2026 he was recognised in the OpenUK New Year Honours for his open source contributions.',
+		bio: 'Chris Lloyd-Jones is VP for AI Consulting Transformation at Kyndryl, where he created and leads the Forward Deployed Engineering capability that pairs engineers directly with clients. A seven-time Microsoft MVP, in AI and Developer Technologies, he is also a doctoral researcher in green software engineering and a contributor to the ISO/IEC 21031:2024 Software Carbon Intensity standard. His work spans agentic AI, open source, and sustainable, secure-by-design systems, and in 2026 he was recognised in the OpenUK New Year Honours for his open source contributions.',
 		links: [
 			{ label: 'Website', href: 'https://sealjay.com/about' },
 			{ label: 'LinkedIn', href: 'https://www.linkedin.com/in/chrislloydjones/' },
@@ -28,7 +28,7 @@ export const AUTHORS: Record<'chris' | 'josh', Author> = {
 		id: 'josh',
 		name: 'Josh McDonald',
 		role: 'Data & AI Security Lead · Avanade',
-		bio: "Josh McDonald is a Microsoft MVP in AI, awarded in the Trustworthy AI category, and a data and AI security specialist at Avanade. He leads Avanade's Global Security SME team and its Data Security community of practice, working closely with the Microsoft product group on Microsoft Purview and driving security innovation within the Office of the CTO. On his KnowledgeRatio blog he explores the intersection of AI, work, and security, championing least-privilege and trustworthy AI for the enterprise.",
+		bio: "Josh McDonald is a two-time Microsoft MVP in AI, awarded in the Trustworthy AI category, and a data and AI security specialist at Avanade. He leads Avanade's Global Security SME team and its Data Security community of practice, working closely with the Microsoft product group on Microsoft Purview and driving security innovation within the Office of the CTO. On his KnowledgeRatio blog he explores the intersection of AI, work, and security, championing least-privilege and trustworthy AI for the enterprise.",
 		links: [
 			{ label: 'Blog', href: 'https://knowledgeratio.github.io/KnowledgeRatio/' },
 			{ label: 'LinkedIn', href: 'https://www.linkedin.com/in/joshmcdonalduk/' },

--- a/src/utils/podcast.ts
+++ b/src/utils/podcast.ts
@@ -1,15 +1,27 @@
 export interface PodcastPlatform {
 	label: string;
 	href: string;
+	/** Primary destinations, rendered as filled cartridges. The rest are outlined. */
+	filled?: boolean;
 }
 
 // Single source of truth for the podcast's listen/subscribe surfaces.
 // The show has no custom podcast RSS feed.
 export const PODCAST_PLATFORMS: readonly PodcastPlatform[] = [
-	{ label: 'Spotify', href: 'https://open.spotify.com/show/1Yo0bHunKuloEXda0Zn3t2' },
+	{ label: 'YouTube', href: 'https://www.youtube.com/@SecuringTheRealm', filled: true },
 	{
 		label: 'Apple Podcasts',
 		href: 'https://podcasts.apple.com/gb/podcast/securing-the-realm/id1835736136',
+		filled: true,
 	},
-	{ label: 'YouTube', href: 'https://www.youtube.com/@SecuringTheRealm' },
+	{ label: 'Spotify', href: 'https://open.spotify.com/show/1Yo0bHunKuloEXda0Zn3t2' },
+	{ label: 'Deezer', href: 'https://www.deezer.com/en/show/1003402722' },
+	{
+		label: 'iHeartRadio',
+		href: 'https://www.iheart.com/podcast/269-securing-the-realm-338714716/',
+	},
+	{
+		label: 'Amazon Music',
+		href: 'https://music.amazon.co.uk/podcasts/8b7e89e9-f458-499f-9237-987f6db85708/securing-the-realm',
+	},
 ] as const;

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,6 +1,6 @@
 import type { CollectionEntry } from 'astro:content';
 import { getCollection } from 'astro:content';
-import { fetchYouTubeShorts, fetchYouTubeTalks } from './youtube';
+import { fetchYouTubeShorts, fetchYouTubeTalks, toSummary } from './youtube';
 
 export interface SearchItem {
 	type: 'blog' | 'talk' | 'project' | 'short';
@@ -40,7 +40,7 @@ export async function buildSearchIndex(): Promise<SearchItem[]> {
 		items.push({
 			type: 'talk',
 			title: talk.data.title,
-			description: `${talk.data.event}: ${talk.data.summary}`,
+			description: toSummary(`${talk.data.event}: ${talk.data.summary}`, 120),
 			url: `/talks/#${talk.id}`,
 			date: talk.data.date,
 			tags: talk.data.tags,
@@ -53,7 +53,7 @@ export async function buildSearchIndex(): Promise<SearchItem[]> {
 		items.push({
 			type: 'talk',
 			title: talk.title,
-			description: `${talk.event}: ${talk.summary}`,
+			description: toSummary(`${talk.event}: ${talk.summary}`, 120),
 			url: `/talks/#youtube-${index}`,
 			date: talk.date,
 			tags: talk.tags,
@@ -66,7 +66,8 @@ export async function buildSearchIndex(): Promise<SearchItem[]> {
 		items.push({
 			type: 'short',
 			title: short.title,
-			description: short.description || 'A short from the Securing the Realm YouTube channel.',
+			description:
+				toSummary(short.description, 120) || 'A short from the Securing the Realm YouTube channel.',
 			url: short.videoUrl,
 			date: short.pubDate,
 			tags: short.tags,

--- a/src/utils/youtube.test.ts
+++ b/src/utils/youtube.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, test } from 'bun:test';
+import { toSummary, toTitle } from './youtube';
+
+describe('toSummary', () => {
+	test('strips the URLs and hashtags that tags and relatedContent already carry', () => {
+		expect(
+			toSummary(
+				'What happens when AI deletes your codebase? Whoops!\nFull video: https://www.youtube.com/watch?v=aUEcOlT5eMA\n#AI #GenAI #MVPBuzz'
+			)
+		).toBe('What happens when AI deletes your codebase? Whoops!');
+	});
+
+	test('truncates on a word boundary, never mid-word', () => {
+		const summary = toSummary('alpha bravo charlie delta echo', 14);
+		expect(summary).toBe('alpha bravo…');
+	});
+
+	test('leaves short descriptions alone', () => {
+		expect(toSummary('A short from the channel.')).toBe('A short from the channel.');
+	});
+
+	test('drops a "Full video:" line rather than stranding the label', () => {
+		expect(
+			toSummary(
+				'Imagine AI could just join the conversation. Not because you asked it to - but because it knew when to.\nFull video: https://www.youtube.com/watch?v=_OaCJceqgho\n#AI #GenAI #MVPBuzz'
+			)
+		).toBe(
+			'Imagine AI could just join the conversation. Not because you asked it to - but because it knew when to.'
+		);
+	});
+
+	test('drops the whole promo line, not just the URL inside it', () => {
+		// The call to action continues past the link ("and find a link to the
+		// original paper"), so removing only the URL leaves "Full video: and
+		// find a link..." pointing at nothing.
+		expect(
+			toSummary(
+				'The future of work isn’t automation versus people. It’s about designing resilient, adaptive systems where both thrive.\nFull video: https://youtu.be/oNmquoKw3oE and find a link to the original paper by Diana Wolfe, Alice Choe and Fergus Kidd.\n#AI #GenAI #MVPBuzz'
+			)
+		).toBe(
+			'The future of work isn’t automation versus people. It’s about designing resilient, adaptive systems where both thrive.'
+		);
+	});
+
+	test('drops an emoji-led promo line', () => {
+		expect(
+			toSummary(
+				"Most people think Microsoft Foundry is just about OpenAI models. It's not.\n\n\u{1F4D6} Microsoft's model catalogue: https://learn.microsoft.com/en-us/azure/ai-foundry/foundry-models/concepts/models-sold-directly-by-azure?WT.mc_id=AI-MVP-5004204"
+			)
+		).toBe("Most people think Microsoft Foundry is just about OpenAI models. It's not.");
+	});
+
+	test('keeps a sentence that merely happens to contain a colon and a link', () => {
+		expect(
+			toSummary('We asked the obvious question: can you trust it? https://example.com/paper')
+		).toBe('We asked the obvious question: can you trust it?');
+	});
+
+	test('keeps a long label that is prose rather than a promo tag', () => {
+		const prose =
+			'The one thing every security team keeps getting wrong about agent identity: https://example.com';
+		expect(toSummary(prose)).toBe(
+			'The one thing every security team keeps getting wrong about agent identity'
+		);
+	});
+
+	test('strips the "delves into" opener and recapitalises', () => {
+		expect(
+			toSummary(
+				'The conversation delves into the evolving landscape of AI and securing it, focusing on regulatory and legal drivers.'
+			)
+		).toBe(
+			'The evolving landscape of AI and securing it, focusing on regulatory and legal drivers.'
+		);
+	});
+
+	test('strips "In this conversation," but keeps who is speaking', () => {
+		expect(
+			toSummary(
+				'In this conversation, Chris Lloyd-Jones and Josh McDonald discuss the use of Foundry Local for securely generating sensitive AI content.'
+			)
+		).toBe(
+			'Chris Lloyd-Jones and Josh McDonald discuss the use of Foundry Local for securely generating sensitive AI content.'
+		);
+	});
+
+	test('strips "In this episode of ..." with the comma inside the quotes', () => {
+		expect(
+			toSummary(
+				'In this episode of "Securing the Realm," we discuss the mystifying world of deepfakes and shallow fakes.'
+			)
+		).toBe('We discuss the mystifying world of deepfakes and shallow fakes.');
+	});
+
+	test('leaves the same phrasing alone mid-paragraph, where it carries content', () => {
+		const description =
+			'Who controls access when AI agents handle data and tasks? In this short, we explain how Azure AI Foundry uses Entra ID.';
+		expect(toSummary(description)).toBe(description);
+	});
+
+	test('leaves an opener that is not filler', () => {
+		expect(toSummary('In this age of agents, identity is the new perimeter.')).toBe(
+			'In this age of agents, identity is the new perimeter.'
+		);
+	});
+});
+
+describe('toSummary sentence truncation', () => {
+	// Both descriptions are the real feed text behind excerpts that shipped
+	// dangling mid-clause ("He explores the definition of...", "Kevin McDonnell
+	// shares his...") on the homepage.
+	const NEMA =
+		'Nema Sobhani, a data scientist at Avanade, discusses the concept of agents in AI and their impact on human activities. He explores the definition of agents, their role in the enterprise, and the ethical and social implications of their use. The conversation delves into the evaluation and governance of AI models, as well as the philosophical and practical considerations of human-AI interaction.';
+
+	const KEVIN =
+		'The conversation delves into the future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI. Kevin McDonnell shares his insights and a one of his own take aways from the app that started the series!';
+
+	test('cuts at the last whole sentence instead of dangling on "the definition of"', () => {
+		expect(toSummary(NEMA, 150)).toBe(
+			'Nema Sobhani, a data scientist at Avanade, discusses the concept of agents in AI and their impact on human activities…'
+		);
+	});
+
+	test('cuts at the last whole sentence instead of dangling on "shares his"', () => {
+		expect(toSummary(KEVIN, 220)).toBe(
+			'The future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI…'
+		);
+	});
+
+	test('ends with one ellipsis, not "of AI...." — no doubled punctuation', () => {
+		// The old word-boundary cut landed just past "governance of AI." and
+		// appended "...", giving four dots.
+		const summary = toSummary(KEVIN, 120);
+		expect(summary.endsWith('governance of AI…')).toBe(true);
+		expect(summary).not.toContain('...');
+		expect(summary).not.toContain('.…');
+	});
+
+	test('falls back to a word boundary when one sentence overruns the budget', () => {
+		expect(
+			toSummary(
+				'A single unbroken clause about agentic identity and governance that simply refuses to stop for breath anywhere at all',
+				60
+			)
+		).toBe('A single unbroken clause about agentic identity and…');
+	});
+
+	test('does not split on "vs." in a chapter list', () => {
+		// The only real abbreviation in the YouTube corpus. "Pessimism" is
+		// capitalised, so nothing but the word list distinguishes it.
+		expect(
+			toSummary(
+				'Deepfakes are cheaper to create than ever before, and detection lags behind them. 23:52 Optimism vs. Pessimism in Technology Adoption 27:07 Conclusion and final thoughts from the hosts.',
+				150
+			)
+		).toBe('Deepfakes are cheaper to create than ever before, and detection lags behind them…');
+	});
+
+	test('does not split on a decimal version number', () => {
+		expect(
+			toSummary(
+				'Foundry Local shipped version 9.0 to general availability last week and it changes things.',
+				60
+			)
+		).toBe('Foundry Local shipped version 9.0 to general availability…');
+	});
+
+	test('does not split on initials in a citation', () => {
+		expect(
+			toSummary(
+				'The paper by J. McDonald and A. Choe argues that agent identity is the new perimeter of the enterprise.',
+				60
+			)
+		).toBe('The paper by J. McDonald and A. Choe argues that agent…');
+	});
+
+	test('does not split inside an acronym run like "U.S."', () => {
+		expect(
+			toSummary(
+				'The U.S. regulator published guidance that reshapes how enterprises govern their agent fleets today.',
+				60
+			)
+		).toBe('The U.S. regulator published guidance that reshapes how…');
+	});
+
+	test('still treats a two-letter acronym like "AI." as a real sentence end', () => {
+		// The initials guard must not swallow this: "I" has no word boundary in
+		// front of it, so "AI." stays a sentence end.
+		expect(
+			toSummary(
+				'Everything here is about the commoditization of AI. Kevin then explains what that means for teams.',
+				60
+			)
+		).toBe('Everything here is about the commoditization of AI…');
+	});
+
+	test('ends a sentence on "?" and on "!"', () => {
+		expect(
+			toSummary(
+				'Who controls access when AI agents handle data and tasks? We explain how Foundry uses Entra ID for this.',
+				70
+			)
+		).toBe('Who controls access when AI agents handle data and tasks…');
+
+		expect(
+			toSummary(
+				'What happens when AI deletes your codebase? Whoops! We walk through the whole postmortem in detail.',
+				70
+			)
+		).toBe('What happens when AI deletes your codebase? Whoops…');
+	});
+
+	test('keeps a closing quote that belongs to the sentence it ends', () => {
+		expect(
+			toSummary(
+				'Welcome to a festive "Securing the Realm"! Josh and Chris are joined by Diana Wolfe and Fergus Kidd.',
+				70
+			)
+		).toBe('Welcome to a festive "Securing the Realm"…');
+	});
+
+	test('leaves a description that fits the budget completely alone', () => {
+		// No ellipsis, and the closing full stop survives.
+		expect(toSummary('A short from the channel.', 200)).toBe('A short from the channel.');
+	});
+});
+
+describe('toSummary em dash normalisation', () => {
+	test('turns the real unspaced "security—confidentiality" pair into spaced hyphens', () => {
+		// A comma would flatten this into a four-item list and lose that
+		// security is the thing the other three define.
+		expect(
+			toSummary(
+				'They explore the CIA triangle of security—confidentiality, integrity, and availability—and how Microsoft Purview serves as a data security solution.',
+				200
+			)
+		).toBe(
+			'They explore the CIA triangle of security - confidentiality, integrity, and availability - and how Microsoft Purview serves as a data security solution.'
+		);
+	});
+
+	test('collapses a spaced em dash to a single spaced hyphen', () => {
+		expect(
+			toSummary('Agent identity — the new perimeter — is what teams keep getting wrong.', 200)
+		).toBe('Agent identity - the new perimeter - is what teams keep getting wrong.');
+	});
+
+	test('normalises en dashes too, so a reviewer sees no stray dash characters', () => {
+		expect(toSummary('The 2024–2025 shift changed how enterprises govern their agents.', 200)).toBe(
+			'The 2024 - 2025 shift changed how enterprises govern their agents.'
+		);
+	});
+
+	test('does not mangle a dash inside a URL, because the URL is already gone', () => {
+		expect(toSummary('Read the write-up https://example.com/a—b/c for the full detail.', 200)).toBe(
+			'Read the write-up for the full detail.'
+		);
+	});
+
+	test('leaves no dangling hyphen when the budget cuts at a normalised dash', () => {
+		expect(
+			toSummary('Securing the realm of agents — confidentiality and integrity matter here.', 40)
+		).toBe('Securing the realm of agents…');
+	});
+});
+
+describe('toTitle', () => {
+	test('drops the trailing hashtag run', () => {
+		expect(toTitle('Agentic AI - Quickfire with Kevin McDonnell #ai #agents')).toBe(
+			'Agentic AI - Quickfire with Kevin McDonnell'
+		);
+	});
+
+	test('keeps a title that is nothing but hashtags', () => {
+		expect(toTitle('#shorts')).toBe('#shorts');
+	});
+});

--- a/src/utils/youtube.test.ts
+++ b/src/utils/youtube.test.ts
@@ -105,35 +105,75 @@ describe('toSummary', () => {
 	});
 });
 
-describe('toSummary sentence truncation', () => {
-	// Both descriptions are the real feed text behind excerpts that shipped
-	// dangling mid-clause ("He explores the definition of...", "Kevin McDonnell
-	// shares his...") on the homepage.
-	const NEMA =
-		'Nema Sobhani, a data scientist at Avanade, discusses the concept of agents in AI and their impact on human activities. He explores the definition of agents, their role in the enterprise, and the ethical and social implications of their use. The conversation delves into the evaluation and governance of AI models, as well as the philosophical and practical considerations of human-AI interaction.';
+// The raw YouTube descriptions behind three of the five Quest Log rows on the
+// homepage, copied verbatim from the feed. NEMA and ROUNDUP carry the Takeaways
+// and Chapters sections that the whitespace collapse folds into one line.
+const NEMA =
+	'Nema Sobhani, a data scientist at Avanade, discusses the concept of agents in AI and their impact on human activities. He explores the definition of agents, their role in the enterprise, and the ethical and social implications of their use. The conversation delves into the evaluation and governance of AI models, as well as the philosophical and practical considerations of human-AI interaction.\n\nTakeaways\n\n* Agents as AI entities are empowered to perform tasks autonomously, and they will increasingly become integral to various business functions, disrupting the org-chart.\n* The evaluation and governance of AI models are crucial in ensuring their ethical, and responsible use in enterprise settings and as a key part of AI governance.\n\nChapters\n\n* 00:00 Introduction to Agents in AI\n* 07:58 Ethical and Social Implications of Agents\n* 16:24 Evaluation and Governance of AI Models\n* 26:20 Human Activities and the Role of AI';
 
-	const KEVIN =
-		'The conversation delves into the future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI. Kevin McDonnell shares his insights and a one of his own take aways from the app that started the series!';
+const ROUNDUP =
+	'The conversation delves into the evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges, open source and commodification, and the nature of observability. Each chapter explores these themes in depth, providing valuable insights into the current state of AI technology and its impact on various industries.\n\n\n\nTakeaways\n\n* Regulatory and legal drivers to Agentic Security\n* Are models being commoditised?\n* Security and governance challenges\n* Open Source\n* Observability and security';
 
-	test('cuts at the last whole sentence instead of dangling on "the definition of"', () => {
-		expect(toSummary(NEMA, 150)).toBe(
-			'Nema Sobhani, a data scientist at Avanade, discusses the concept of agents in AI and their impact on human activities…'
-		);
-	});
+const KEVIN =
+	'The conversation delves into the future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI. Kevin McDonnell shares his insights and a one of his own take aways from the app that started the series!';
 
-	test('cuts at the last whole sentence instead of dangling on "shares his"', () => {
-		expect(toSummary(KEVIN, 220)).toBe(
-			'The future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI…'
-		);
-	});
+describe('Quest Log homepage rows', () => {
+	// The homepage does not call toSummary on the raw feed text: fetchYouTubeTalks
+	// and fetchYouTubeShorts summarise at the default 200 first, and index.astro
+	// re-summarises that at 150. All three of these shipped cut mid-clause with a
+	// trailing "…"; a row now always ends on the sentence's own punctuation.
+	const row = (description: string): string => toSummary(toSummary(description), 150);
 
-	test('ends with one ellipsis, not "of AI...." — no doubled punctuation', () => {
-		// The old word-boundary cut landed just past "governance of AI." and
-		// appended "...", giving four dots.
-		const summary = toSummary(KEVIN, 120);
-		expect(summary.endsWith('governance of AI…')).toBe(true);
+	test.each([
+		['NEMA', NEMA],
+		['ROUNDUP', ROUNDUP],
+		['KEVIN', KEVIN],
+	])('%s ends on a full stop with no ellipsis', (_name: string, description: string) => {
+		const summary = row(description);
+		expect(summary.endsWith('.')).toBe(true);
+		expect(summary).not.toContain('…');
 		expect(summary).not.toContain('...');
-		expect(summary).not.toContain('.…');
+	});
+
+	test('keeps the whole opening sentence of the Nema row', () => {
+		expect(row(NEMA)).toBe(
+			'Nema Sobhani, a data scientist at Avanade, discusses the concept of agents in AI and their impact on human activities.'
+		);
+	});
+
+	test('keeps the whole roundup sentence rather than cutting its list short', () => {
+		// 214 characters against a 150 budget: the sentence has no earlier break,
+		// and running over is the lesser evil next to "...governance challenges…".
+		expect(row(ROUNDUP)).toBe(
+			'The evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges, open source and commodification, and the nature of observability.'
+		);
+	});
+
+	test('keeps the whole opening sentence of the Kevin row', () => {
+		expect(row(KEVIN)).toBe(
+			'The future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI.'
+		);
+	});
+});
+
+describe('toSummary sentence truncation', () => {
+	test('stops after the first whole sentence rather than starting a second', () => {
+		expect(toSummary(NEMA, 150)).toBe(
+			'Nema Sobhani, a data scientist at Avanade, discusses the concept of agents in AI and their impact on human activities.'
+		);
+	});
+
+	test('keeps the sentence-ending full stop, with no ellipsis after it', () => {
+		expect(toSummary(KEVIN, 220)).toBe(
+			'The future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI.'
+		);
+	});
+
+	test('ends with one full stop, not "of AI…." — no doubled punctuation', () => {
+		const summary = toSummary(KEVIN, 120);
+		expect(summary.endsWith('governance of AI.')).toBe(true);
+		expect(summary).not.toContain('...');
+		expect(summary).not.toContain('…');
 	});
 
 	test('falls back to a word boundary when one sentence overruns the budget', () => {
@@ -149,22 +189,27 @@ describe('toSummary sentence truncation', () => {
 
 	test('does not split on "vs." in a chapter list', () => {
 		// The only real abbreviation in the YouTube corpus. "Pessimism" is
-		// capitalised, so nothing but the word list distinguishes it.
+		// capitalised, so nothing but the word list distinguishes it. Reading it as
+		// a sentence end would take the excerpt to "...Optimism vs.", which fits.
 		expect(
 			toSummary(
 				'Deepfakes are cheaper to create than ever before, and detection lags behind them. 23:52 Optimism vs. Pessimism in Technology Adoption 27:07 Conclusion and final thoughts from the hosts.',
 				150
 			)
-		).toBe('Deepfakes are cheaper to create than ever before, and detection lags behind them…');
+		).toBe('Deepfakes are cheaper to create than ever before, and detection lags behind them.');
 	});
 
 	test('does not split on a decimal version number', () => {
+		// If "9.0" read as a sentence end the excerpt would stop at "version 9.",
+		// well inside the budget. It runs to the real full stop instead.
 		expect(
 			toSummary(
 				'Foundry Local shipped version 9.0 to general availability last week and it changes things.',
 				60
 			)
-		).toBe('Foundry Local shipped version 9.0 to general availability…');
+		).toBe(
+			'Foundry Local shipped version 9.0 to general availability last week and it changes things.'
+		);
 	});
 
 	test('does not split on initials in a citation', () => {
@@ -173,7 +218,9 @@ describe('toSummary sentence truncation', () => {
 				'The paper by J. McDonald and A. Choe argues that agent identity is the new perimeter of the enterprise.',
 				60
 			)
-		).toBe('The paper by J. McDonald and A. Choe argues that agent…');
+		).toBe(
+			'The paper by J. McDonald and A. Choe argues that agent identity is the new perimeter of the enterprise.'
+		);
 	});
 
 	test('does not split inside an acronym run like "U.S."', () => {
@@ -182,18 +229,21 @@ describe('toSummary sentence truncation', () => {
 				'The U.S. regulator published guidance that reshapes how enterprises govern their agent fleets today.',
 				60
 			)
-		).toBe('The U.S. regulator published guidance that reshapes how…');
+		).toBe(
+			'The U.S. regulator published guidance that reshapes how enterprises govern their agent fleets today.'
+		);
 	});
 
 	test('still treats a two-letter acronym like "AI." as a real sentence end', () => {
 		// The initials guard must not swallow this: "I" has no word boundary in
-		// front of it, so "AI." stays a sentence end.
+		// front of it, so "AI." stays a sentence end and the second sentence is
+		// dropped rather than joined on.
 		expect(
 			toSummary(
 				'Everything here is about the commoditization of AI. Kevin then explains what that means for teams.',
 				60
 			)
-		).toBe('Everything here is about the commoditization of AI…');
+		).toBe('Everything here is about the commoditization of AI.');
 	});
 
 	test('ends a sentence on "?" and on "!"', () => {
@@ -202,14 +252,14 @@ describe('toSummary sentence truncation', () => {
 				'Who controls access when AI agents handle data and tasks? We explain how Foundry uses Entra ID for this.',
 				70
 			)
-		).toBe('Who controls access when AI agents handle data and tasks…');
+		).toBe('Who controls access when AI agents handle data and tasks?');
 
 		expect(
 			toSummary(
 				'What happens when AI deletes your codebase? Whoops! We walk through the whole postmortem in detail.',
 				70
 			)
-		).toBe('What happens when AI deletes your codebase? Whoops…');
+		).toBe('What happens when AI deletes your codebase? Whoops!');
 	});
 
 	test('keeps a closing quote that belongs to the sentence it ends', () => {
@@ -218,7 +268,7 @@ describe('toSummary sentence truncation', () => {
 				'Welcome to a festive "Securing the Realm"! Josh and Chris are joined by Diana Wolfe and Fergus Kidd.',
 				70
 			)
-		).toBe('Welcome to a festive "Securing the Realm"…');
+		).toBe('Welcome to a festive "Securing the Realm"!');
 	});
 
 	test('leaves a description that fits the budget completely alone', () => {
@@ -227,15 +277,14 @@ describe('toSummary sentence truncation', () => {
 	});
 });
 
-describe('toSummary clause-boundary fallback', () => {
+describe('toSummary sentences that overrun the budget', () => {
 	// Every fixture in this block is the exact feed text behind an excerpt that
-	// shipped dangling mid-clause. ROUNDUP and ARCHITECTURE are the two /talks/
-	// excerpts ("...and the nature of…", "...Alice Choe and Fergus…"); the rest
-	// reach the search index, which composes "<event>: <summary>" and so has
-	// roughly 30 characters less room than the page it came from.
-	const ROUNDUP =
-		'The conversation delves into the evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges, open source and commodification, and the nature of observability. Each chapter explores these themes in depth, providing valuable insights into the current state of AI technology and its impact on various industries.';
-
+	// shipped dangling mid-clause. ARCHITECTURE is a /talks/ excerpt
+	// ("...Alice Choe and Fergus…"); the rest reach the search index, which
+	// composes "<event>: <summary>" and so has roughly 30 characters less room
+	// than the page it came from. A whole sentence is now returned even when it
+	// overruns; the clause and word fallbacks survive only for a sentence past
+	// double the budget, and for text carrying no sentence punctuation at all.
 	const ARCHITECTURE =
 		'Diana Wolfe joins Chris and Josh to discuss the new paper "The Architecture of AI Transformation: Four Strategic Patterns and an Emerging Frontier" co-authored by Diana Wolfe, Alice Choe and Fergus Kidd; and discussing the transformative potential of AI in organizations, exploring the concept of agentic AI and its implications for leadership and collaboration.';
 
@@ -248,25 +297,25 @@ describe('toSummary clause-boundary fallback', () => {
 	const DEEPFAKES =
 		'In this episode of "Securing the Realm," we discuss the mystifying world of deepfakes and shallow fakes and their implications for security and media trust. Hosts Josh McDonald and Chris Lloyd-Jones - with special guest Fergus Kidd - guide you through real examples of deepfakes.';
 
-	test('cuts the list at a comma instead of dangling on "and the nature of"', () => {
-		// The first sentence runs to 240 characters, so no sentence break fits a
-		// 200 budget at all. The comma after "commodification" sits at 93% of the
-		// budget, so almost nothing is given up to land on it.
+	test('keeps the whole list sentence instead of dangling on "and the nature of"', () => {
+		// The first sentence runs to 214 characters, so nothing fits a 200 budget.
+		// Cutting at the comma after "commodification" would drop two list items
+		// and still read as an interrupted sentence.
 		expect(toSummary(ROUNDUP, 200)).toBe(
-			'The evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges, open source and commodification…'
+			'The evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges, open source and commodification, and the nature of observability.'
 		);
 	});
 
 	test('does not cut a co-author list in the middle of a name', () => {
-		// Shipped as "...Alice Choe and Fergus…", chopping Fergus Kidd in half.
-		expect(toSummary(ARCHITECTURE, 200)).toBe(
-			'Diana Wolfe joins Chris and Josh to discuss the new paper "The Architecture of AI Transformation: Four Strategic Patterns and an Emerging Frontier" co-authored by Diana Wolfe…'
-		);
+		// Shipped as "...Alice Choe and Fergus…", chopping Fergus Kidd in half. One
+		// sentence of 359 characters, inside the 400 an overrun allows here.
+		expect(toSummary(ARCHITECTURE, 200)).toBe(ARCHITECTURE);
 	});
 
 	test('keeps the quoted paper title whole rather than cutting at its colon', () => {
-		// The title carries its own colon a third of the way into a 150 budget.
-		// Taking it would cost half the excerpt, which the clause floor forbids.
+		// 359 characters against a 150 budget is past double, so the sentence is
+		// cut after all. The title carries its own colon a third of the way in;
+		// taking it would cost half the excerpt, which the clause floor forbids.
 		expect(toSummary(ARCHITECTURE, 150)).toBe(
 			'Diana Wolfe joins Chris and Josh to discuss the new paper "The Architecture of AI Transformation: Four Strategic Patterns and an Emerging Frontier"…'
 		);
@@ -276,26 +325,27 @@ describe('toSummary clause-boundary fallback', () => {
 		// That colon is only 28 characters in, so honouring it would leave the
 		// search result showing nothing but the show name.
 		expect(toSummary(`YouTube - Securing the Realm: ${toSummary(VIBE_CODING)}`, 120)).toBe(
-			'YouTube - Securing the Realm: Chris and Josh explore the latest features of GitHub Copilot…'
+			'YouTube - Securing the Realm: Chris and Josh explore the latest features of GitHub Copilot, particularly focusing on agentic AI and its implications for software development.'
 		);
 	});
 
-	test('trims a dangling preposition when only a word boundary is available', () => {
-		// No clause punctuation in the budget at all, so this is the word-boundary
-		// path. Shipped as "...securing communications in…".
+	test('does not strand a preposition in a search index entry', () => {
+		// Shipped as "...securing communications in…".
 		expect(toSummary(`YouTube - Securing the Realm: ${toSummary(PURVIEW)}`, 120)).toBe(
-			'YouTube - Securing the Realm: Josh McDonald and Chris Lloyd-Jones discuss the importance of securing communications…'
+			'YouTube - Securing the Realm: Josh McDonald and Chris Lloyd-Jones discuss the importance of securing communications in the realm of agentic AI.'
 		);
 	});
 
-	test('trims a dangling "for" rather than pointing at nothing', () => {
-		// Shipped as "...and their implications for…".
+	test('keeps "their implications for security and media trust" whole', () => {
+		// Shipped as "...and their implications for…", pointing at nothing.
 		expect(toSummary(`YouTube - Securing the Realm: ${toSummary(DEEPFAKES)}`, 120)).toBe(
-			'YouTube - Securing the Realm: We discuss the mystifying world of deepfakes and shallow fakes and their implications…'
+			'YouTube - Securing the Realm: We discuss the mystifying world of deepfakes and shallow fakes and their implications for security and media trust.'
 		);
 	});
 
 	test('trims a whole dangling "and the" run, not just the last word', () => {
+		// An excerpt that already ends in "…" carries no sentence punctuation at
+		// all, so the word-boundary path is the only one left.
 		expect(
 			toSummary(
 				'YouTube - Securing the Realm: The future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI…',
@@ -306,17 +356,13 @@ describe('toSummary clause-boundary fallback', () => {
 		);
 	});
 
-	test('re-truncating an already-summarised excerpt stays clean', () => {
-		// The homepage and the search index both feed toSummary its own output,
-		// and the "…" it appended is not a sentence break, so the second pass has
-		// to find its own resting place.
+	test('re-truncating an already-summarised excerpt is a no-op', () => {
+		// The homepage and the search index both feed toSummary its own output.
+		// Because the first pass ends on a full stop, the second pass sees a whole
+		// sentence and has nothing left to do.
 		const once = toSummary(ROUNDUP, 200);
-		const twice = toSummary(once, 150);
-		expect(twice).toBe(
-			'The evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges…'
-		);
-		expect(twice).not.toContain('…,');
-		expect(twice.split('…')).toHaveLength(2);
+		expect(toSummary(once, 150)).toBe(once);
+		expect(once).not.toContain('…');
 	});
 
 	test('prefers a real sentence break over any clause boundary', () => {
@@ -327,7 +373,7 @@ describe('toSummary clause-boundary fallback', () => {
 				"Most people think Microsoft Foundry is just about OpenAI models. It's not. If you're building on Azure and only looking at OpenAI endpoints, you're leaving options on the table.",
 				150
 			)
-		).toBe("Most people think Microsoft Foundry is just about OpenAI models. It's not…");
+		).toBe("Most people think Microsoft Foundry is just about OpenAI models. It's not.");
 	});
 
 	test('ignores a clause boundary too early in the budget to be worth taking', () => {
@@ -390,8 +436,9 @@ describe('toSummary em dash normalisation', () => {
 	});
 
 	test('leaves no dangling hyphen when the budget cuts at a normalised dash', () => {
+		// 72 characters against a 30 budget: past double, so this one is cut.
 		expect(
-			toSummary('Securing the realm of agents — confidentiality and integrity matter here.', 40)
+			toSummary('Securing the realm of agents — confidentiality and integrity matter here.', 30)
 		).toBe('Securing the realm of agents…');
 	});
 });

--- a/src/utils/youtube.test.ts
+++ b/src/utils/youtube.test.ts
@@ -137,12 +137,14 @@ describe('toSummary sentence truncation', () => {
 	});
 
 	test('falls back to a word boundary when one sentence overruns the budget', () => {
+		// No sentence break and no clause punctuation anywhere in the budget, so
+		// the word boundary is all that is left. The dangling "and" still goes.
 		expect(
 			toSummary(
 				'A single unbroken clause about agentic identity and governance that simply refuses to stop for breath anywhere at all',
 				60
 			)
-		).toBe('A single unbroken clause about agentic identity and…');
+		).toBe('A single unbroken clause about agentic identity…');
 	});
 
 	test('does not split on "vs." in a chapter list', () => {
@@ -222,6 +224,136 @@ describe('toSummary sentence truncation', () => {
 	test('leaves a description that fits the budget completely alone', () => {
 		// No ellipsis, and the closing full stop survives.
 		expect(toSummary('A short from the channel.', 200)).toBe('A short from the channel.');
+	});
+});
+
+describe('toSummary clause-boundary fallback', () => {
+	// Every fixture in this block is the exact feed text behind an excerpt that
+	// shipped dangling mid-clause. ROUNDUP and ARCHITECTURE are the two /talks/
+	// excerpts ("...and the nature of…", "...Alice Choe and Fergus…"); the rest
+	// reach the search index, which composes "<event>: <summary>" and so has
+	// roughly 30 characters less room than the page it came from.
+	const ROUNDUP =
+		'The conversation delves into the evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges, open source and commodification, and the nature of observability. Each chapter explores these themes in depth, providing valuable insights into the current state of AI technology and its impact on various industries.';
+
+	const ARCHITECTURE =
+		'Diana Wolfe joins Chris and Josh to discuss the new paper "The Architecture of AI Transformation: Four Strategic Patterns and an Emerging Frontier" co-authored by Diana Wolfe, Alice Choe and Fergus Kidd; and discussing the transformative potential of AI in organizations, exploring the concept of agentic AI and its implications for leadership and collaboration.';
+
+	const VIBE_CODING =
+		'In this conversation, Chris and Josh explore the latest features of GitHub Copilot, particularly focusing on agentic AI and its implications for software development. They discuss the concept of vibe engineering versus vibe coding, emphasizing the need for subject matter expertise when utilizing AI tools.';
+
+	const PURVIEW =
+		'In this conversation, Josh McDonald and Chris Lloyd-Jones discuss the importance of securing communications in the realm of agentic AI. They explore the CIA triangle of security—confidentiality, integrity, and availability—and how Microsoft Purview serves as a data security solution.';
+
+	const DEEPFAKES =
+		'In this episode of "Securing the Realm," we discuss the mystifying world of deepfakes and shallow fakes and their implications for security and media trust. Hosts Josh McDonald and Chris Lloyd-Jones - with special guest Fergus Kidd - guide you through real examples of deepfakes.';
+
+	test('cuts the list at a comma instead of dangling on "and the nature of"', () => {
+		// The first sentence runs to 240 characters, so no sentence break fits a
+		// 200 budget at all. The comma after "commodification" sits at 93% of the
+		// budget, so almost nothing is given up to land on it.
+		expect(toSummary(ROUNDUP, 200)).toBe(
+			'The evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges, open source and commodification…'
+		);
+	});
+
+	test('does not cut a co-author list in the middle of a name', () => {
+		// Shipped as "...Alice Choe and Fergus…", chopping Fergus Kidd in half.
+		expect(toSummary(ARCHITECTURE, 200)).toBe(
+			'Diana Wolfe joins Chris and Josh to discuss the new paper "The Architecture of AI Transformation: Four Strategic Patterns and an Emerging Frontier" co-authored by Diana Wolfe…'
+		);
+	});
+
+	test('keeps the quoted paper title whole rather than cutting at its colon', () => {
+		// The title carries its own colon a third of the way into a 150 budget.
+		// Taking it would cost half the excerpt, which the clause floor forbids.
+		expect(toSummary(ARCHITECTURE, 150)).toBe(
+			'Diana Wolfe joins Chris and Josh to discuss the new paper "The Architecture of AI Transformation: Four Strategic Patterns and an Emerging Frontier"…'
+		);
+	});
+
+	test('does not cut at the "<event>:" colon the search index prepends', () => {
+		// That colon is only 28 characters in, so honouring it would leave the
+		// search result showing nothing but the show name.
+		expect(toSummary(`YouTube - Securing the Realm: ${toSummary(VIBE_CODING)}`, 120)).toBe(
+			'YouTube - Securing the Realm: Chris and Josh explore the latest features of GitHub Copilot…'
+		);
+	});
+
+	test('trims a dangling preposition when only a word boundary is available', () => {
+		// No clause punctuation in the budget at all, so this is the word-boundary
+		// path. Shipped as "...securing communications in…".
+		expect(toSummary(`YouTube - Securing the Realm: ${toSummary(PURVIEW)}`, 120)).toBe(
+			'YouTube - Securing the Realm: Josh McDonald and Chris Lloyd-Jones discuss the importance of securing communications…'
+		);
+	});
+
+	test('trims a dangling "for" rather than pointing at nothing', () => {
+		// Shipped as "...and their implications for…".
+		expect(toSummary(`YouTube - Securing the Realm: ${toSummary(DEEPFAKES)}`, 120)).toBe(
+			'YouTube - Securing the Realm: We discuss the mystifying world of deepfakes and shallow fakes and their implications…'
+		);
+	});
+
+	test('trims a whole dangling "and the" run, not just the last word', () => {
+		expect(
+			toSummary(
+				'YouTube - Securing the Realm: The future of AI, discussing its accessibility, the concept of ambient computing, and the ethical governance of AI…',
+				120
+			)
+		).toBe(
+			'YouTube - Securing the Realm: The future of AI, discussing its accessibility, the concept of ambient computing…'
+		);
+	});
+
+	test('re-truncating an already-summarised excerpt stays clean', () => {
+		// The homepage and the search index both feed toSummary its own output,
+		// and the "…" it appended is not a sentence break, so the second pass has
+		// to find its own resting place.
+		const once = toSummary(ROUNDUP, 200);
+		const twice = toSummary(once, 150);
+		expect(twice).toBe(
+			'The evolving landscape of AI and securing it, focusing on regulatory and legal drivers, the commoditization of AI, security & governance challenges…'
+		);
+		expect(twice).not.toContain('…,');
+		expect(twice.split('…')).toHaveLength(2);
+	});
+
+	test('prefers a real sentence break over any clause boundary', () => {
+		// The clause floor must not outrank a whole sentence that fits, even when
+		// the sentence uses less than half the budget.
+		expect(
+			toSummary(
+				"Most people think Microsoft Foundry is just about OpenAI models. It's not. If you're building on Azure and only looking at OpenAI endpoints, you're leaving options on the table.",
+				150
+			)
+		).toBe("Most people think Microsoft Foundry is just about OpenAI models. It's not…");
+	});
+
+	test('ignores a clause boundary too early in the budget to be worth taking', () => {
+		// "Well," is 5 characters into a 120 budget. Cutting there would throw the
+		// excerpt away to buy a comma, so the word boundary wins instead.
+		expect(
+			toSummary(
+				'Well, the whole point of an agent identity perimeter is that every single call carries a verifiable claim about who is asking and why they want it',
+				120
+			)
+		).toBe(
+			'Well, the whole point of an agent identity perimeter is that every single call carries a verifiable claim about who is…'
+		);
+	});
+
+	test('does not read a chapter timestamp as a clause boundary', () => {
+		// "23:52" would otherwise offer a colon; the lookahead needs whitespace
+		// straight after it, and a timestamp has a digit there.
+		expect(
+			toSummary(
+				'Deepfakes are cheaper to create than ever before and detection lags well behind 23:52 Optimism and Pessimism in Technology Adoption 27:07 Conclusion',
+				120
+			)
+		).toBe(
+			'Deepfakes are cheaper to create than ever before and detection lags well behind 23:52 Optimism and Pessimism…'
+		);
 	});
 });
 

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -140,6 +140,113 @@ function extractHashtagTags(description: string): string[] {
 	);
 }
 
+// YouTube titles often end in a hashtag run ("... #ai #agents"). Those are
+// already tags; in a heading they are just noise.
+export function toTitle(title: string): string {
+	return title.replace(/(\s+#[\w-]+)+\s*$/, '').trim() || title;
+}
+
+// Call-to-action lines: a short label, a colon, then a link — "Full video:",
+// "GitHub Repo:", "Learn more:", "📖 Microsoft's model catalogue:". Stripping
+// only the URL strands the label ("...Whoops! Full video"), so drop the whole
+// line, including any trailing "and find a link to the paper" that likewise
+// only made sense while the link was there. Guards: the label is capped at 40
+// characters and may not contain sentence-ending punctuation, so a real
+// sentence that happens to quote a URL is left alone.
+const PROMO_LINE = /^[^\n.!?:]{0,40}:[ \t]*https?:\/\/\S+.*$/gm;
+
+// "The conversation delves into X" — "delves" is a well-worn LLM tell, and
+// "the conversation" is a contentless subject, so promote X to the front.
+const DELVES_OPENER = /^The (?:conversation|discussion) delves into /i;
+
+// "In this conversation, ..." / 'In this episode of "Securing the Realm," ...'
+// Scene-setting filler ahead of the real sentence. The optional quote covers
+// the show name being quoted with the comma inside the quotes.
+const SCENE_SETTING_OPENER = /^In this (?:conversation|episode|short)\b[^,\n]{0,50},["'”’]?\s+/i;
+
+// Only the leading preamble is stripped: the same phrasing mid-paragraph is
+// usually carrying real content by then.
+function stripOpener(text: string): string {
+	const stripped = text.replace(DELVES_OPENER, '').replace(SCENE_SETTING_OPENER, '');
+	return stripped === text ? text : stripped.charAt(0).toUpperCase() + stripped.slice(1);
+}
+
+// Sentence-ending punctuation, plus any closing quote or bracket carried along
+// with it ('the Realm"!'). The trailing lookahead is the main defence: a real
+// break is always followed by whitespace, so a decimal ("version 9.0"), a URL
+// path ("arxiv.org/abs/2509.02853") and a file name never read as sentence ends.
+const SENTENCE_END = /[.!?]+["'”’)\]]*(?=\s|$)/g;
+
+// Full stops that do not end a sentence. "vs." is the only one that actually
+// occurs in the YouTube corpus ("23:52 Optimism vs. Pessimism in Technology"),
+// where the following word is capitalised and so gives nothing else away. The
+// titles and Latin tags are cheap insurance for a corpus that cites papers and
+// co-authors. The trailing single-letter alternative covers initials
+// ("J. McDonald") and acronym runs ("U.S."), whose final dot is likewise
+// preceded by a lone letter — "of AI." is not caught, because "I" has no word
+// boundary in front of it, so it stays a real sentence end.
+// Missing an entry here costs a mid-sentence cut; a spurious one only costs a
+// missed break, so this list errs towards over-listing.
+const ABBREVIATION = /(?:\b(?:vs|etc|eg|ie|al|approx|Dr|Mr|Mrs|Ms|Prof)|\b[A-Za-z])\.$/;
+
+// Whitespace and dangling clause punctuation, so the ellipsis never lands on
+// "AI.…" or "agents,…".
+const TRAILING_PUNCTUATION = /[\s.,:;!?-]+$/;
+
+// The house style is a spaced hyphen and the site ships no em dashes, but the
+// descriptions are YouTube's copy, not ours. Every em dash in the corpus is an
+// appositive, spaced or not ("the CIA triangle of security—confidentiality,
+// integrity, and availability—"), and a comma would flatten that one into a
+// four-item list, so a spaced hyphen replaces both forms. Swallowing the
+// surrounding whitespace is what lets the two forms share a rule. Applied after
+// the URL strip, so a dash inside a link is already gone rather than mangled.
+// ponytail: en dashes get the same spaced hyphen, so a numeric range would come
+// out as "2024 - 2025". The corpus has no en dashes at all; split the rule if
+// one ever shows up.
+const EM_DASH = /\s*[—–]\s*/g;
+
+// Index of the last sentence break inside `text`, or -1 when there is none to
+// trust. Abbreviations are re-tested against the text up to and including the
+// dot, so the check sees the word the dot is attached to.
+function lastSentenceBreak(text: string): number {
+	let breakAt = -1;
+	for (const match of text.matchAll(SENTENCE_END)) {
+		const index = match.index ?? 0;
+		if (ABBREVIATION.test(text.slice(0, index + 1))) continue;
+		breakAt = index;
+	}
+	return breakAt;
+}
+
+/**
+ * Turns a raw YouTube description into display copy: the URLs and hashtags are
+ * already harvested into relatedContent and tags, so on the page they are noise.
+ * Drops promo lines and filler openers, normalises em dashes to the house
+ * spaced hyphen, then truncates at the last complete
+ * sentence that fits, falling back to a word boundary when the budget holds no
+ * sentence break at all (a single very long sentence still has to render).
+ */
+export function toSummary(description: string, maxLength = 200): string {
+	const cleaned = stripOpener(
+		description
+			.replace(PROMO_LINE, '')
+			.replace(/https?:\/\/\S+/g, '')
+			.replace(/#[\w-]+/g, '')
+			.replace(EM_DASH, ' - ')
+			.replace(/\s+/g, ' ')
+			.trim()
+	).replace(/[\s,:;-]+$/, '');
+
+	if (cleaned.length <= maxLength) return cleaned;
+
+	const budget = cleaned.slice(0, maxLength);
+	const sentenceBreak = lastSentenceBreak(budget);
+	const wordBreak = budget.lastIndexOf(' ');
+	const cut = sentenceBreak > 0 ? sentenceBreak : wordBreak > 0 ? wordBreak : budget.length;
+
+	return `${budget.slice(0, cut).replace(TRAILING_PUNCTUATION, '')}…`;
+}
+
 // Module-level cache to avoid redundant fetches during a single build.
 // Multiple pages call fetchYouTubeTalks() (directly and via buildSearchIndex),
 // so caching saves N-1 HTTP requests to YouTube during static generation.
@@ -175,11 +282,10 @@ export async function fetchYouTubeTalks(): Promise<YouTubeTalk[]> {
 		// Combine and deduplicate tags
 		const allTags = [...new Set([...defaultTags, ...extractedTags])];
 
-		// Truncate description to a reasonable length for summary
-		const summary = description.length > 200 ? `${description.substring(0, 197)}...` : description;
+		const summary = toSummary(description);
 
 		return {
-			title: entry.title,
+			title: toTitle(entry.title),
 			date: publishedDate,
 			event: 'YouTube - Securing the Realm',
 			videoUrl,
@@ -252,8 +358,8 @@ export async function fetchYouTubeShorts(): Promise<YouTubeShort[]> {
 
 		return {
 			id: videoId,
-			title: entry.title,
-			description,
+			title: toTitle(entry.title),
+			description: toSummary(description),
 			pubDate: publishedDate,
 			thumbnailUrl,
 			videoUrl,

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -226,18 +226,33 @@ const TRAILING_FUNCTION_WORD =
 // one ever shows up.
 const EM_DASH = /\s*[—–]\s*/g;
 
+// A first sentence may run over budget rather than be clipped, but only so far:
+// past double the budget it has stopped being an excerpt, and a tidy cut beats
+// pasting a paragraph into a one-line row.
+const OVERRUN_LIMIT = 2;
+
 // Index of the last `breakPattern` match inside `text`, or -1 when there is
-// none to trust. `reject` is re-tested against the text up to and including the
-// matched character, so an abbreviation check sees the word its dot is attached
-// to.
-function lastBreak(text: string, breakPattern: RegExp, reject?: RegExp): number {
+// none.
+function lastBreak(text: string, breakPattern: RegExp): number {
 	let breakAt = -1;
 	for (const match of text.matchAll(breakPattern)) {
-		const index = match.index ?? 0;
-		if (reject?.test(text.slice(0, index + 1))) continue;
-		breakAt = index;
+		breakAt = match.index ?? 0;
 	}
 	return breakAt;
+}
+
+// End offsets (exclusive, so the full stop and any closing quote are included)
+// of every sentence in `text`, in order. ABBREVIATION is re-tested against the
+// text up to and including the matched dot, so the check sees the word the dot
+// is attached to.
+function sentenceEnds(text: string): number[] {
+	const ends: number[] = [];
+	for (const match of text.matchAll(SENTENCE_END)) {
+		const index = match.index ?? 0;
+		if (ABBREVIATION.test(text.slice(0, index + 1))) continue;
+		ends.push(index + match[0].length);
+	}
+	return ends;
 }
 
 // Tidies the ragged edge of a word-boundary cut: drop trailing punctuation, then
@@ -257,13 +272,17 @@ function trimDangling(fragment: string): string {
  * Turns a raw YouTube description into display copy: the URLs and hashtags are
  * already harvested into relatedContent and tags, so on the page they are noise.
  * Drops promo lines and filler openers, normalises em dashes to the house
- * spaced hyphen, then truncates at the last complete sentence that fits.
+ * spaced hyphen, then keeps as many whole sentences as fit the budget. The
+ * excerpt ends on the sentence's own punctuation, never on an ellipsis: a cut
+ * in the middle of a clause reads as broken copy even when the sentence it
+ * came from was complete.
  *
- * A single very long sentence still has to render, so when the budget holds no
- * sentence break the cut falls back, in order, to the last clause boundary in
- * the final quarter of the budget, then to the last word boundary with any
- * stranded function word trimmed off. Both fallbacks end the excerpt somewhere
- * a reader would pause, rather than wherever the character count ran out.
+ * When not even the first sentence fits, that whole sentence is returned
+ * anyway - a few characters over budget is cheaper than a clause dangling in
+ * mid-air, and the row's line height absorbs it. Only a sentence past
+ * OVERRUN_LIMIT times the budget is clipped, falling back to the last clause
+ * boundary in the final quarter of the budget, then to the last word boundary
+ * with any stranded function word trimmed off.
  */
 export function toSummary(description: string, maxLength = 200): string {
 	const cleaned = stripOpener(
@@ -278,12 +297,16 @@ export function toSummary(description: string, maxLength = 200): string {
 
 	if (cleaned.length <= maxLength) return cleaned;
 
-	const budget = cleaned.slice(0, maxLength);
-
-	const sentenceBreak = lastBreak(budget, SENTENCE_END, ABBREVIATION);
-	if (sentenceBreak > 0) {
-		return `${budget.slice(0, sentenceBreak).replace(TRAILING_PUNCTUATION, '')}…`;
+	const ends = sentenceEnds(cleaned);
+	const fitting = ends.filter((end: number) => end <= maxLength);
+	if (fitting.length > 0) {
+		return cleaned.slice(0, fitting[fitting.length - 1]);
 	}
+	if (ends.length > 0 && ends[0] <= maxLength * OVERRUN_LIMIT) {
+		return cleaned.slice(0, ends[0]);
+	}
+
+	const budget = cleaned.slice(0, maxLength);
 
 	const clauseBreak = lastBreak(budget, CLAUSE_END);
 	if (clauseBreak >= maxLength * CLAUSE_FLOOR) {

--- a/src/utils/youtube.ts
+++ b/src/utils/youtube.ts
@@ -193,6 +193,27 @@ const ABBREVIATION = /(?:\b(?:vs|etc|eg|ie|al|approx|Dr|Mr|Mrs|Ms|Prof)|\b[A-Za-
 // "AI.…" or "agents,…".
 const TRAILING_PUNCTUATION = /[\s.,:;!?-]+$/;
 
+// Clause-level punctuation, used as the second-choice cut when the budget holds
+// no sentence break. Same trailing-whitespace lookahead as SENTENCE_END, so a
+// timestamp ("23:52 Optimism"), a ratio and a thousands separator are not
+// mistaken for clause ends.
+const CLAUSE_END = /[,;:]["'”’)\]]*(?=\s)/g;
+
+// A clause cut is only worth taking near the end of the budget. Two real cases
+// argue for a high bar: the search index composes "<event>: <summary>", putting
+// a colon about a quarter of the way in, and a quoted paper title carries its
+// own colon ('"The Architecture of AI Transformation: Four Strategic..."').
+// Cutting at either throws away most of the excerpt to buy a tidier edge.
+const CLAUSE_FLOOR = 0.75;
+
+// Function words that must not be the last word of a word-boundary cut. Without
+// this the fallback dangles on the preposition it stopped in front of:
+// "...their implications for…", "...securing communications in…", "...the
+// concept of agents in AI and…". Content words are never listed, so the trim
+// can only ever drop grammatical scaffolding, never a fact.
+const TRAILING_FUNCTION_WORD =
+	/\s+(?:a|an|and|as|at|but|by|for|from|in|into|its|of|on|or|the|their|to|with)$/i;
+
 // The house style is a spaced hyphen and the site ships no em dashes, but the
 // descriptions are YouTube's copy, not ours. Every em dash in the corpus is an
 // appositive, spaced or not ("the CIA triangle of security—confidentiality,
@@ -205,26 +226,44 @@ const TRAILING_PUNCTUATION = /[\s.,:;!?-]+$/;
 // one ever shows up.
 const EM_DASH = /\s*[—–]\s*/g;
 
-// Index of the last sentence break inside `text`, or -1 when there is none to
-// trust. Abbreviations are re-tested against the text up to and including the
-// dot, so the check sees the word the dot is attached to.
-function lastSentenceBreak(text: string): number {
+// Index of the last `breakPattern` match inside `text`, or -1 when there is
+// none to trust. `reject` is re-tested against the text up to and including the
+// matched character, so an abbreviation check sees the word its dot is attached
+// to.
+function lastBreak(text: string, breakPattern: RegExp, reject?: RegExp): number {
 	let breakAt = -1;
-	for (const match of text.matchAll(SENTENCE_END)) {
+	for (const match of text.matchAll(breakPattern)) {
 		const index = match.index ?? 0;
-		if (ABBREVIATION.test(text.slice(0, index + 1))) continue;
+		if (reject?.test(text.slice(0, index + 1))) continue;
 		breakAt = index;
 	}
 	return breakAt;
+}
+
+// Tidies the ragged edge of a word-boundary cut: drop trailing punctuation, then
+// any function word now left stranded, and repeat, so "computing, and the" comes
+// back as "computing" rather than "computing, and".
+function trimDangling(fragment: string): string {
+	let trimmed = fragment.replace(TRAILING_PUNCTUATION, '');
+	let previous = '';
+	while (previous !== trimmed) {
+		previous = trimmed;
+		trimmed = trimmed.replace(TRAILING_FUNCTION_WORD, '').replace(TRAILING_PUNCTUATION, '');
+	}
+	return trimmed;
 }
 
 /**
  * Turns a raw YouTube description into display copy: the URLs and hashtags are
  * already harvested into relatedContent and tags, so on the page they are noise.
  * Drops promo lines and filler openers, normalises em dashes to the house
- * spaced hyphen, then truncates at the last complete
- * sentence that fits, falling back to a word boundary when the budget holds no
- * sentence break at all (a single very long sentence still has to render).
+ * spaced hyphen, then truncates at the last complete sentence that fits.
+ *
+ * A single very long sentence still has to render, so when the budget holds no
+ * sentence break the cut falls back, in order, to the last clause boundary in
+ * the final quarter of the budget, then to the last word boundary with any
+ * stranded function word trimmed off. Both fallbacks end the excerpt somewhere
+ * a reader would pause, rather than wherever the character count ran out.
  */
 export function toSummary(description: string, maxLength = 200): string {
 	const cleaned = stripOpener(
@@ -240,11 +279,19 @@ export function toSummary(description: string, maxLength = 200): string {
 	if (cleaned.length <= maxLength) return cleaned;
 
 	const budget = cleaned.slice(0, maxLength);
-	const sentenceBreak = lastSentenceBreak(budget);
-	const wordBreak = budget.lastIndexOf(' ');
-	const cut = sentenceBreak > 0 ? sentenceBreak : wordBreak > 0 ? wordBreak : budget.length;
 
-	return `${budget.slice(0, cut).replace(TRAILING_PUNCTUATION, '')}…`;
+	const sentenceBreak = lastBreak(budget, SENTENCE_END, ABBREVIATION);
+	if (sentenceBreak > 0) {
+		return `${budget.slice(0, sentenceBreak).replace(TRAILING_PUNCTUATION, '')}…`;
+	}
+
+	const clauseBreak = lastBreak(budget, CLAUSE_END);
+	if (clauseBreak >= maxLength * CLAUSE_FLOOR) {
+		return `${budget.slice(0, clauseBreak).replace(TRAILING_PUNCTUATION, '')}…`;
+	}
+
+	const wordBreak = budget.lastIndexOf(' ');
+	return `${trimDangling(budget.slice(0, wordBreak > 0 ? wordBreak : budget.length))}…`;
 }
 
 // Module-level cache to avoid redundant fetches during a single build.


### PR DESCRIPTION
## Summary

Dependabot alert clearance plus the homepage identity rebuild and spacing-token work that landed on top of it.

- **Deps:** sharp 0.35.3, astro 7.1.3 — clears outstanding Dependabot alerts.
- **Homepage:** identity rebuild, accessible castle navigation, new privacy and contact pages.
- **Spacing:** consolidated the ad-hoc padding/margin values into a token system on the 8px grid; every homepage section seam now resolves to a single `--space-section`.
- **Rhythm/QA:** two passes of measured spacing fixes (`qa/measure.mjs` added to check section gaps).
- **Perf:** `VideoFacade` and `EpisodePoster` components so embeds load on interaction rather than on page load.
- **Tests/CI:** `src/utils/youtube.test.ts` (456 lines) and a `.github/workflows/test.yml` running lint + typecheck + build.

31 files changed, +3075 / −764.

## Test plan

- [ ] `bun run build` passes (zero TypeScript errors, zero Biome errors)
- [ ] `bun run test` passes
- [ ] Homepage spacing checked at mobile / tablet / desktop breakpoints
- [ ] Castle scene keyboard-navigable, ARIA labels present
- [ ] Video facades load the real embed on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017hz2KqeTRM4cvABX5Tfcwb
